### PR TITLE
perf: add bf16 gemv primitive

### DIFF
--- a/astrai/extension/__init__.py
+++ b/astrai/extension/__init__.py
@@ -49,6 +49,7 @@ from astrai.extension.ops import (
     attn_decode,
     attn_paged_decode,
     attn_prefill,
+    bf16_gemv,
 )
 
 __all__ = [
@@ -65,6 +66,7 @@ __all__ = [
     "attn_decode",
     "attn_paged_decode",
     "attn_prefill",
+    "bf16_gemv",
     "is_available",
     "KERNEL_NAMES",
     "apply_rotary_emb",

--- a/astrai/extension/ops/__init__.py
+++ b/astrai/extension/ops/__init__.py
@@ -7,6 +7,7 @@ from astrai.extension.ops.attention import (
     attn_paged_prefill,
     attn_prefill,
 )
+from astrai.extension.ops.gemv import bf16_gemv
 from astrai.extension.ops.rotary import rotary_emb
 
 __all__ = [
@@ -15,5 +16,6 @@ __all__ = [
     "attn_paged_decode",
     "attn_paged_prefill",
     "attn_prefill",
+    "bf16_gemv",
     "rotary_emb",
 ]

--- a/astrai/extension/ops/gemv.py
+++ b/astrai/extension/ops/gemv.py
@@ -1,0 +1,22 @@
+"""Stateless wrapper for the directly callable BF16 GEMV primitive."""
+
+from typing import Optional
+
+import torch
+
+from astrai.extension.loader import get_module
+
+
+def bf16_gemv(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Compute ``F.linear(x, weight, bias)`` for a single BF16 input row.
+
+    ``x`` must have shape ``[K]`` or ``[1, K]`` and ``weight`` must be a
+    contiguous row-major ``[N, K]`` tensor. The CUDA kernel accumulates in
+    FP32 and returns BF16. This primitive is inference-only and intentionally
+    performs no fallback or model-level dispatch.
+    """
+    return get_module("bf16_gemv").bf16_gemv(x, weight, bias)

--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -61,6 +61,7 @@ set(KERNEL_NAMES
     attn_prefill
     attn_paged_decode
     attn_paged_prefill
+    bf16_gemv
     rotary_emb
 )
 set(KERNEL_SRCS
@@ -68,6 +69,7 @@ set(KERNEL_SRCS
     attention/prefill.cu
     attention/paged_decode.cu
     attention/paged_prefill.cu
+    gemv/bf16_gemv.cu
     rotary_emb.cu
 )
 

--- a/csrc/kernels/gemv/bf16_gemv.cu
+++ b/csrc/kernels/gemv/bf16_gemv.cu
@@ -1,0 +1,150 @@
+// Directly callable M=1 BF16 GEMV primitive for decode-time linear layers.
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#include <cuda_bf16.h>
+#include <torch/extension.h>
+
+#include <cstdint>
+#include <limits>
+
+namespace {
+
+constexpr int kThreads = 256;
+constexpr int kWarpSize = 32;
+
+__device__ __forceinline__ float warp_sum(float value) {
+#pragma unroll
+    for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
+        value += __shfl_down_sync(0xffffffff, value, offset);
+    }
+    return value;
+}
+
+__global__ void bf16_gemv_kernel(
+    const __nv_bfloat16* __restrict__ x,
+    const __nv_bfloat16* __restrict__ weight,
+    const __nv_bfloat16* __restrict__ bias,
+    __nv_bfloat16* __restrict__ output,
+    int k
+) {
+    const int row = blockIdx.x;
+    const int lane = threadIdx.x & (kWarpSize - 1);
+    const int warp = threadIdx.x / kWarpSize;
+    const int pairs = k / 2;
+    const auto* x2 = reinterpret_cast<const __nv_bfloat162*>(x);
+    const auto* w2 = reinterpret_cast<const __nv_bfloat162*>(weight) + row * pairs;
+
+    float sum = 0.0f;
+    for (int pair = threadIdx.x; pair < pairs; pair += blockDim.x) {
+        const __nv_bfloat162 xv = x2[pair];
+        const __nv_bfloat162 wv = w2[pair];
+        sum = fmaf(
+            __bfloat162float(__low2bfloat16(xv)),
+            __bfloat162float(__low2bfloat16(wv)),
+            sum
+        );
+        sum = fmaf(
+            __bfloat162float(__high2bfloat16(xv)),
+            __bfloat162float(__high2bfloat16(wv)),
+            sum
+        );
+    }
+
+    sum = warp_sum(sum);
+    __shared__ float warp_sums[kThreads / kWarpSize];
+    if (lane == 0) {
+        warp_sums[warp] = sum;
+    }
+    __syncthreads();
+
+    if (warp == 0) {
+        sum = lane < (kThreads / kWarpSize) ? warp_sums[lane] : 0.0f;
+        sum = warp_sum(sum);
+        if (lane == 0) {
+            if (bias != nullptr) {
+                sum += __bfloat162float(bias[row]);
+            }
+            output[row] = __float2bfloat16_rn(sum);
+        }
+    }
+}
+
+torch::Tensor bf16_gemv(
+    torch::Tensor x,
+    torch::Tensor weight,
+    py::object bias_object
+) {
+    TORCH_CHECK(x.is_cuda() && weight.is_cuda(), "x and weight must be CUDA tensors");
+    TORCH_CHECK(x.device() == weight.device(), "x and weight must share device");
+    TORCH_CHECK(
+        x.scalar_type() == torch::kBFloat16 &&
+            weight.scalar_type() == torch::kBFloat16,
+        "x and weight must be bf16"
+    );
+    TORCH_CHECK(
+        x.dim() == 1 || (x.dim() == 2 && x.size(0) == 1),
+        "x must have shape [K] or [1, K]"
+    );
+    TORCH_CHECK(weight.dim() == 2, "weight must have shape [N, K]");
+    TORCH_CHECK(x.is_contiguous() && weight.is_contiguous(), "x and weight must be contiguous");
+    TORCH_CHECK(
+        !x.requires_grad() && !weight.requires_grad(),
+        "bf16_gemv is inference-only and does not support autograd"
+    );
+
+    const int64_t k = x.size(-1);
+    const int64_t n = weight.size(0);
+    TORCH_CHECK(weight.size(1) == k, "weight K must match x K");
+    TORCH_CHECK(k > 0 && n > 0, "N and K must be positive");
+    TORCH_CHECK(k % 2 == 0, "K must be even for vectorized bf16 loads");
+    TORCH_CHECK(
+        k <= std::numeric_limits<int>::max() &&
+            n <= std::numeric_limits<int>::max(),
+        "N or K exceeds the CUDA launcher limit"
+    );
+
+    torch::Tensor bias;
+    const __nv_bfloat16* bias_ptr = nullptr;
+    if (!bias_object.is_none()) {
+        bias = bias_object.cast<torch::Tensor>();
+        TORCH_CHECK(bias.is_cuda() && bias.device() == x.device(), "bias must share the CUDA device");
+        TORCH_CHECK(bias.scalar_type() == torch::kBFloat16, "bias must be bf16");
+        TORCH_CHECK(bias.dim() == 1 && bias.size(0) == n, "bias must have shape [N]");
+        TORCH_CHECK(bias.is_contiguous(), "bias must be contiguous");
+        TORCH_CHECK(!bias.requires_grad(), "bf16_gemv bias does not support autograd");
+        bias_ptr = reinterpret_cast<const __nv_bfloat16*>(bias.data_ptr());
+    }
+
+    const at::cuda::OptionalCUDAGuard guard(x.device());
+    const auto* properties = at::cuda::getDeviceProperties(x.device().index());
+    TORCH_CHECK(properties->major >= 8, "bf16_gemv requires compute capability 8.0+");
+    auto stream = at::cuda::getCurrentCUDAStream();
+    auto output = x.dim() == 1
+        ? torch::empty({n}, x.options())
+        : torch::empty({1, n}, x.options());
+
+    bf16_gemv_kernel<<<static_cast<int>(n), kThreads, 0, stream.stream()>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x.data_ptr()),
+        reinterpret_cast<const __nv_bfloat16*>(weight.data_ptr()),
+        bias_ptr,
+        reinterpret_cast<__nv_bfloat16*>(output.data_ptr()),
+        static_cast<int>(k)
+    );
+    C10_CUDA_CHECK(cudaGetLastError());
+    return output;
+}
+
+}  // namespace
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, module) {
+    module.def(
+        "bf16_gemv",
+        &bf16_gemv,
+        py::arg("x"),
+        py::arg("weight"),
+        py::arg("bias") = py::none(),
+        "M=1 BF16 GEMV with FP32 accumulation and optional fused bias"
+    );
+}

--- a/docs/developer/cuda_kernels.md
+++ b/docs/developer/cuda_kernels.md
@@ -1,6 +1,9 @@
 # CUDA Kernels
 
-AstrAI includes optional custom CUDA kernels for attention, rotary embedding, and FP8 GEMM. These are built when `nvcc` is available and CUDA is detected, and are dispatched via the `CudaBackend` attention backend, auto-dispatched for rotary, or invoked through the FP8 linear primitives.
+AstrAI includes optional custom CUDA kernels for attention, rotary embedding,
+BF16 GEMV, and FP8 GEMM. These are built when `nvcc` is available and CUDA is
+detected. BF16 GEMV is a directly callable primitive and does not change model
+linear dispatch.
 
 ## Overview
 
@@ -11,7 +14,20 @@ AstrAI includes optional custom CUDA kernels for attention, rotary embedding, an
 | `attn_paged_decode` | `attention/paged_decode.cu` | Paged KV cache decode attention |
 | `attn_paged_prefill` | `attention/paged_prefill.cu` | Paged KV cache prefill attention (ragged batch) |
 | `rotary_emb` | `rotary_emb.cu` | Fused rotary embedding (cos/sin lookup + rotation) |
+| `bf16_gemv` | `gemv/bf16_gemv.cu` | M=1 BF16 linear with FP32 accumulation (sm_80+) |
 | `fp8_ops` | `fp8/ops.cu` | FP8 quantization + tensor-core GEMM (sm_89+) |
+
+### BF16 GEMV primitive
+
+`astrai.extension.bf16_gemv(x, weight, bias=None)` accepts a contiguous BF16
+input shaped `[K]` or `[1, K]` and row-major weights `[N, K]`. One CTA reduces
+each output row using vectorized `__nv_bfloat162` loads and FP32 accumulation;
+the optional BF16 bias is fused before the BF16 store. The launcher uses the
+current CUDA stream, is CUDA Graph capture-safe, and requires sm_80 or newer.
+
+The primitive is inference-only and deliberately has no `F.linear` fallback or
+model-level dispatch. Dispatch is added separately only for shape bands with a
+measured win over each architecture's own cuBLAS baseline.
 
 Additionally, optimized `.cuh` variants with tensor-core MMA (Matrix Multiply-Accumulate) exist:
 
@@ -202,6 +218,7 @@ astrai/extension/
 ├── ops/
 │   ├── attention.py        # Stateless attention kernel wrappers
 │   ├── rotary.py           # Stateless rotary kernel wrapper
+│   ├── gemv.py             # Stateless BF16 GEMV primitive
 │   └── fp8.py              # Stateless FP8 primitives (custom_op)
 ├── fp8.py                  # FP8 strategy layer (fp8_autocast, recipes)
 └── backend/

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,7 @@ class _CMakeBuildExt(_build_ext):
             "attn_prefill",
             "attn_paged_decode",
             "attn_paged_prefill",
+            "bf16_gemv",
             "rotary_emb",
         )
         missing = [name for name in required if not any(lib_dir.glob(f"{name}.*.so"))]

--- a/tests/extension/test_gemv.py
+++ b/tests/extension/test_gemv.py
@@ -1,0 +1,113 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+from astrai.extension import bf16_gemv, is_available
+
+GEMV_AVAILABLE = (
+    torch.cuda.is_available()
+    and is_available("bf16_gemv")
+    and torch.cuda.get_device_capability() >= (8, 0)
+)
+skip_no_gemv = pytest.mark.skipif(
+    not GEMV_AVAILABLE,
+    reason="BF16 GEMV requires a built kernel and compute capability 8.0+",
+)
+
+
+@skip_no_gemv
+@pytest.mark.parametrize(
+    "n,k",
+    [(256, 1536), (1536, 1536), (6912, 1536), (1536, 6912), (100000, 1536)],
+)
+def test_bf16_gemv_matches_linear_shape_families(n, k):
+    torch.manual_seed(17)
+    x = torch.randn(k, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(n, k, device="cuda", dtype=torch.bfloat16)
+    actual = bf16_gemv(x, weight)
+    expected = F.linear(x, weight)
+    assert actual.shape == (n,)
+    torch.testing.assert_close(actual, expected, rtol=0.02, atol=0.25)
+
+
+@skip_no_gemv
+def test_bf16_gemv_preserves_singleton_batch_and_fuses_bias():
+    torch.manual_seed(23)
+    x = torch.randn(1, 1536, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(1536, 1536, device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn(1536, device="cuda", dtype=torch.bfloat16)
+    actual = bf16_gemv(x, weight, bias)
+    expected = F.linear(x, weight, bias)
+    assert actual.shape == (1, 1536)
+    torch.testing.assert_close(actual, expected, rtol=0.02, atol=0.25)
+
+
+@skip_no_gemv
+def test_bf16_gemv_uses_current_stream():
+    x = torch.randn(1536, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(256, 1536, device="cuda", dtype=torch.bfloat16)
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        actual = bf16_gemv(x, weight)
+        expected = F.linear(x, weight)
+    stream.synchronize()
+    torch.testing.assert_close(actual, expected, rtol=0.02, atol=0.25)
+
+
+@skip_no_gemv
+def test_bf16_gemv_cuda_graph_replay():
+    torch.manual_seed(29)
+    x = torch.randn(1536, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(1536, 1536, device="cuda", dtype=torch.bfloat16)
+    for _ in range(3):
+        bf16_gemv(x, weight)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = bf16_gemv(x, weight)
+
+    x.copy_(torch.randn_like(x))
+    graph.replay()
+    expected = F.linear(x, weight)
+    torch.testing.assert_close(actual, expected, rtol=0.02, atol=0.25)
+
+
+@skip_no_gemv
+@pytest.mark.parametrize(
+    "make_args,error",
+    [
+        (
+            lambda: (
+                torch.randn(2, 16, device="cuda", dtype=torch.bfloat16),
+                torch.randn(8, 16, device="cuda", dtype=torch.bfloat16),
+            ),
+            "shape",
+        ),
+        (
+            lambda: (
+                torch.randn(15, device="cuda", dtype=torch.bfloat16),
+                torch.randn(8, 15, device="cuda", dtype=torch.bfloat16),
+            ),
+            "even",
+        ),
+        (
+            lambda: (
+                torch.randn(16, device="cuda", dtype=torch.float16),
+                torch.randn(8, 16, device="cuda", dtype=torch.float16),
+            ),
+            "bf16",
+        ),
+        (
+            lambda: (
+                torch.randn(
+                    16, device="cuda", dtype=torch.bfloat16, requires_grad=True
+                ),
+                torch.randn(8, 16, device="cuda", dtype=torch.bfloat16),
+            ),
+            "autograd",
+        ),
+    ],
+)
+def test_bf16_gemv_rejects_unsupported_inputs(make_args, error):
+    with pytest.raises(RuntimeError, match=error):
+        bf16_gemv(*make_args())


### PR DESCRIPTION
_This PR replaces #33 because the original commits were attributed to the wrong GitHub account. The code and validation evidence are unchanged; the commit author and committer are now correctly linked to 0z5a._

## Summary
- add a directly callable SM80+ BF16 GEMV primitive for M=1 decode linear layers
- use vectorized BF16 loads, FP32 accumulation, optional fused bias, the current CUDA stream, and CUDA Graph-safe launches
- keep the primitive inference-only and separate from model dispatch so losing shapes still use PyTorch

## L20 benchmark
Exact PR commit `0f12c6f`, NVIDIA L20 (SM89), BF16, PyTorch 2.11.0+cu128, CUDA 12.8. No bias; 10 A-B-B-A rounds, 300 iterations per sample (80 for LM head). Relative speed is `F.linear / bf16_gemv - 1`.

| shape | N x K | F.linear | bf16_gemv | relative |
|---|---:|---:|---:|---:|
| KV projection | 256 x 1536 | 0.01261 ms | 0.00522 ms | +141.4% |
| Q/O projection | 1536 x 1536 | 0.01249 ms | 0.00528 ms | +136.6% |
| MLP up/gate | 6912 x 1536 | 0.01267 ms | 0.01276 ms | -0.7% |
| MLP down | 1536 x 6912 | 0.01270 ms | 0.00993 ms | +27.9% |
| LM head | 100000 x 1536 | 0.42052 ms | 0.40553 ms | +3.7% |

The mixed result is intentional evidence for keeping dispatch out of this primitive PR. Only proven shape bands should opt in later.

## Correctness and validation
- tested AstrAI projection/MLP/LM-head families against `F.linear`
- tested fused bias, current-stream execution, CUDA Graph replay, input guards, and no-autograd contract
- full pre-commit suite passed on GPU5
- commit author and committer resolve to `0z5a`