### PR TITLE
perf: dispatch decode linear to bf16 gemv

### DIFF
--- a/astrai/extension/__init__.py
+++ b/astrai/extension/__init__.py
@@ -26,6 +26,7 @@ from astrai.extension.backend import (
     attention,
     attn_backend,
     get_backend,
+    linear,
 )
 from astrai.extension.dispatch import (
     Axes,
@@ -63,6 +64,7 @@ __all__ = [
     "attention",
     "attn_backend",
     "get_backend",
+    "linear",
     "attn_decode",
     "attn_paged_decode",
     "attn_prefill",

--- a/astrai/extension/backend/__init__.py
+++ b/astrai/extension/backend/__init__.py
@@ -11,6 +11,7 @@ from astrai.extension.backend.attention import (
     attn_backend,
     get_backend,
 )
+from astrai.extension.backend.linear import linear
 from astrai.extension.backend.rotary import apply_rotary_emb
 
 __all__ = [
@@ -24,4 +25,5 @@ __all__ = [
     "attention",
     "attn_backend",
     "get_backend",
+    "linear",
 ]

--- a/astrai/extension/backend/linear.py
+++ b/astrai/extension/backend/linear.py
@@ -1,0 +1,240 @@
+"""Inference-only dispatch for AstrAI linear layers.
+
+The CUDA GEMV path is deliberately narrow: automatic selection is enabled
+only for single-row BF16 shapes measured to beat ``F.linear`` on a supported
+architecture. Every training, prefill, unsupported-layout, and unmeasured
+call falls back to PyTorch.
+"""
+
+import logging
+import os
+from functools import lru_cache
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+from astrai.extension.dispatch import (
+    ImplRecord,
+    Spec,
+    axis,
+    get_override,
+    register_family,
+    resolve,
+    tensor_axes,
+)
+from astrai.extension.loader import is_available
+from astrai.extension.ops.gemv import bf16_gemv
+
+logger = logging.getLogger(__name__)
+
+# Shape keys are (N, K) for Y[M, N] = X[M, K] @ W[N, K].T. A band is
+# automatic only after both the per-shape >=5% and end-to-end decode >=3%
+# gates pass. L20 micro-winners did not produce a stable whole-graph win, so
+# SM89 intentionally has no automatic entries yet. Mode 1 remains available
+# for explicit A/B runs without weakening the default.
+_AUTO_GEMV_SHAPES: dict[tuple[int, int], frozenset[tuple[int, int]]] = {}
+
+_VALID_MODES = {"0", "1", "auto"}
+_WARNED_MODES: set[str] = set()
+
+
+def _gemv_mode() -> str:
+    mode = os.environ.get("ASTRAI_GEMV", "auto").strip().lower()
+    if mode in _VALID_MODES:
+        return mode
+    if mode not in _WARNED_MODES:
+        _WARNED_MODES.add(mode)
+        logger.warning(
+            "ASTRAI_GEMV=%r is invalid; expected 0, 1, or auto; using auto",
+            mode,
+        )
+    return "auto"
+
+
+def _axes(
+    x: Tensor, weight: Tensor, bias: Optional[Tensor] = None
+) -> dict[str, object]:
+    x_shape = tuple(x.shape)
+    weight_shape = tuple(weight.shape)
+    single_row = x.ndim == 1 or (x.ndim == 2 and x.shape[0] == 1)
+    shape_matches = (
+        weight.ndim == 2
+        and x.ndim in (1, 2)
+        and bool(x_shape)
+        and x_shape[-1] == weight_shape[-1]
+    )
+    same_device = x.device == weight.device and (
+        bias is None or bias.device == x.device
+    )
+    bias_supported = bias is None or (
+        bias.ndim == 1
+        and weight.ndim == 2
+        and bias.shape[0] == weight.shape[0]
+        and bias.dtype == torch.bfloat16
+        and bias.is_contiguous()
+    )
+    capability = torch.cuda.get_device_capability(x.device) if x.is_cuda else None
+    n = weight_shape[0] if weight.ndim == 2 else None
+    k = weight_shape[1] if weight.ndim == 2 else None
+    return tensor_axes(
+        x,
+        mode=_gemv_mode(),
+        capability=capability,
+        n=n,
+        k=k,
+        single_row=single_row,
+        shape_matches=shape_matches,
+        same_device=same_device,
+        weight_dtype=weight.dtype,
+        x_contiguous=x.is_contiguous(),
+        weight_contiguous=weight.is_contiguous(),
+        bias_supported=bias_supported,
+        k_even=k is not None and k % 2 == 0,
+    )
+
+
+_SPEC_CAPABLE = (
+    axis("device_cuda").truthy()
+    & axis("dtype").in_(torch.bfloat16)
+    & axis("weight_dtype").in_(torch.bfloat16)
+    & axis("grad_enabled").eq(False)
+    & axis("single_row").truthy()
+    & axis("shape_matches").truthy()
+    & axis("same_device").truthy()
+    & axis("x_contiguous").truthy()
+    & axis("weight_contiguous").truthy()
+    & axis("bias_supported").truthy()
+    & axis("k_even").truthy()
+)
+
+_SPEC_AUTO = _SPEC_CAPABLE & Spec.of(
+    lambda ax: (
+        (ax.get("n"), ax.get("k")) in _AUTO_GEMV_SHAPES.get(ax.get("capability"), ())
+    ),
+    "shape is a measured winner for this architecture",
+)
+
+
+def _torch_linear(x: Tensor, weight: Tensor, bias: Optional[Tensor] = None) -> Tensor:
+    return F.linear(x, weight, bias)
+
+
+def _inference_bf16_gemv(
+    x: Tensor, weight: Tensor, bias: Optional[Tensor] = None
+) -> Tensor:
+    # Model parameters retain requires_grad=True after eval().  Dispatch is
+    # already restricted to no-grad, so detached views preserve storage and
+    # layout while satisfying the primitive's explicit autograd guard.
+    return bf16_gemv(
+        x.detach(),
+        weight.detach(),
+        bias.detach() if bias is not None else None,
+    )
+
+
+@lru_cache(maxsize=None)
+def _device_capability(device_index: int) -> tuple[int, int]:
+    return torch.cuda.get_device_capability(device_index)
+
+
+def _gemv_capable(x: Tensor, weight: Tensor, bias: Optional[Tensor]) -> bool:
+    if (
+        torch.is_grad_enabled()
+        or not x.is_cuda
+        or x.dtype != torch.bfloat16
+        or weight.dtype != torch.bfloat16
+        or weight.ndim != 2
+        or x.ndim not in (1, 2)
+        or (x.ndim == 2 and x.shape[0] != 1)
+        or x.shape[-1] != weight.shape[1]
+        or weight.shape[1] % 2 != 0
+        or x.device != weight.device
+        or not x.is_contiguous()
+        or not weight.is_contiguous()
+        or not is_available("bf16_gemv")
+    ):
+        return False
+    return bias is None or (
+        bias.device == x.device
+        and bias.dtype == torch.bfloat16
+        and bias.ndim == 1
+        and bias.shape[0] == weight.shape[0]
+        and bias.is_contiguous()
+    )
+
+
+def _auto_gemv_shape(x: Tensor, weight: Tensor) -> bool:
+    capability = _device_capability(x.get_device())
+    return (weight.shape[0], weight.shape[1]) in _AUTO_GEMV_SHAPES.get(capability, ())
+
+
+def _linear_records() -> list[ImplRecord]:
+    mode = _gemv_mode()
+    gemv_priority = 0 if mode == "1" else 100
+    auto_priority = 0 if mode == "auto" else 90
+    torch_priority = 0 if mode == "0" else 50
+    return [
+        ImplRecord(
+            family="linear",
+            name="gemv",
+            obj=_inference_bf16_gemv,
+            spec=_SPEC_CAPABLE,
+            available=lambda: is_available("bf16_gemv"),
+            priority=gemv_priority,
+        ),
+        ImplRecord(
+            family="linear",
+            name="auto_gemv",
+            obj=_inference_bf16_gemv,
+            spec=_SPEC_AUTO,
+            available=lambda: is_available("bf16_gemv"),
+            priority=auto_priority,
+        ),
+        ImplRecord(
+            family="linear",
+            name="torch",
+            obj=_torch_linear,
+            spec=Spec.always(),
+            priority=torch_priority,
+        ),
+    ]
+
+
+def _fallback_record() -> ImplRecord:
+    return ImplRecord(
+        family="linear",
+        name="torch",
+        obj=_torch_linear,
+        spec=Spec.always(),
+        priority=999,
+    )
+
+
+register_family("linear", _axes, _linear_records, _fallback_record)
+
+
+def linear(x: Tensor, weight: Tensor, bias: Optional[Tensor] = None) -> Tensor:
+    """Apply a linear projection with safe inference-only GEMV dispatch.
+
+    ``ASTRAI_GEMV=0`` always uses PyTorch, ``1`` forces GEMV whenever the
+    primitive can safely handle the call, and ``auto`` (the default) uses
+    only architecture/shape bands backed by benchmark evidence.
+    """
+    # Preserve the shared dispatcher for explicit/context selection and
+    # ASTR_OPS diagnostics, while keeping the default per-layer hot path free
+    # of axes dictionaries, record sorting, and repeated capability queries.
+    if get_override("linear") is not None or "linear" in os.environ.get("ASTR_OPS", ""):
+        return resolve("linear", x, weight, bias).record.obj(x, weight, bias)
+
+    mode = _gemv_mode()
+    if mode == "0" or (mode == "auto" and not _AUTO_GEMV_SHAPES):
+        return _torch_linear(x, weight, bias)
+    if mode != "0" and _gemv_capable(x, weight, bias):
+        if mode == "1" or _auto_gemv_shape(x, weight):
+            return _inference_bf16_gemv(x, weight, bias)
+    return _torch_linear(x, weight, bias)
+
+
+__all__ = ["linear"]

--- a/astrai/model/components/linear.py
+++ b/astrai/model/components/linear.py
@@ -1,7 +1,8 @@
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from torch import Tensor
+
+from astrai.extension.backend.linear import linear
 
 
 class Linear(nn.Module):
@@ -21,4 +22,4 @@ class Linear(nn.Module):
             nn.init.uniform_(self.bias, -bound, bound)
 
     def forward(self, x: Tensor) -> Tensor:
-        return F.linear(x, self.weight, self.bias)
+        return linear(x, self.weight, self.bias)

--- a/docs/developer/cuda_kernels.md
+++ b/docs/developer/cuda_kernels.md
@@ -2,8 +2,8 @@
 
 AstrAI includes optional custom CUDA kernels for attention, rotary embedding,
 BF16 GEMV, and FP8 GEMM. These are built when `nvcc` is available and CUDA is
-detected. BF16 GEMV is a directly callable primitive and does not change model
-linear dispatch.
+detected. BF16 GEMV is directly callable and can be selected by the guarded
+model linear dispatcher described below.
 
 ## Overview
 
@@ -25,9 +25,17 @@ each output row using vectorized `__nv_bfloat162` loads and FP32 accumulation;
 the optional BF16 bias is fused before the BF16 store. The launcher uses the
 current CUDA stream, is CUDA Graph capture-safe, and requires sm_80 or newer.
 
-The primitive is inference-only and deliberately has no `F.linear` fallback or
-model-level dispatch. Dispatch is added separately only for shape bands with a
-measured win over each architecture's own cuBLAS baseline.
+Model `Linear` calls route through the lightweight linear backend. Set
+`ASTRAI_GEMV=0` for an unconditional `F.linear` fallback, `1` to force the
+kernel for any supported M=1 call, or `auto` (the default) to select only
+architecture/shape bands that pass both the per-shape and end-to-end gates.
+No SM89 band is automatic yet: isolated L20 winners did not reach the required
+3% stable whole-graph decode improvement, so `auto` currently falls back to
+PyTorch there. Use `1` only for explicit A/B runs. Training, prefill, and
+unsupported calls always remain on PyTorch.
+
+The primitive remains directly callable and deliberately has no internal
+`F.linear` fallback. The model-level backend owns fallback and dispatch policy.
 
 Additionally, optimized `.cuh` variants with tensor-core MMA (Matrix Multiply-Accumulate) exist:
 

--- a/tests/extension/test_linear_dispatch.py
+++ b/tests/extension/test_linear_dispatch.py
@@ -1,0 +1,137 @@
+import logging
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from astrai.extension import explain, is_available, linear, op_backend
+from astrai.extension.backend import linear as public_linear
+from astrai.model.components.linear import Linear
+
+GEMV_AVAILABLE = (
+    torch.cuda.is_available()
+    and is_available("bf16_gemv")
+    and torch.cuda.get_device_capability() >= (8, 0)
+)
+skip_no_gemv = pytest.mark.skipif(
+    not GEMV_AVAILABLE,
+    reason="BF16 GEMV requires a built kernel and compute capability 8.0+",
+)
+
+
+def test_linear_backend_is_public():
+    assert linear is public_linear
+
+
+def test_model_linear_routes_through_backend(monkeypatch):
+    sentinel = torch.randn(2, 4)
+
+    def fake_linear(x, weight, bias):
+        assert x.shape == (2, 3)
+        assert weight.shape == (4, 3)
+        assert bias is None
+        return sentinel
+
+    monkeypatch.setattr("astrai.model.components.linear.linear", fake_linear)
+    layer = Linear(3, 4)
+    assert layer(torch.randn(2, 3)) is sentinel
+
+
+def test_cpu_and_training_calls_fall_back_to_torch(monkeypatch):
+    monkeypatch.setenv("ASTRAI_GEMV", "1")
+    x = torch.randn(2, 8, requires_grad=True)
+    weight = torch.randn(4, 8, requires_grad=True)
+    actual = linear(x, weight)
+    expected = F.linear(x, weight)
+    torch.testing.assert_close(actual, expected)
+    actual.sum().backward()
+    assert x.grad is not None
+    assert weight.grad is not None
+
+
+def test_invalid_mode_warns_and_uses_auto(monkeypatch, caplog):
+    monkeypatch.setenv("ASTRAI_GEMV", "invalid-test-mode")
+    with caplog.at_level(logging.WARNING):
+        trace = explain("linear", torch.randn(1, 8), torch.randn(4, 8))
+    assert "using auto" in caplog.text
+    assert "=> torch" in trace
+
+
+@skip_no_gemv
+def test_mode_zero_disables_gemv(monkeypatch):
+    monkeypatch.setenv("ASTRAI_GEMV", "0")
+    x = torch.randn(1, 1536, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(1536, 1536, device="cuda", dtype=torch.bfloat16)
+    with torch.no_grad():
+        assert "=> torch" in explain("linear", x, weight)
+        torch.testing.assert_close(linear(x, weight), F.linear(x, weight))
+
+
+@skip_no_gemv
+def test_mode_one_forces_capable_unmeasured_shape(monkeypatch):
+    monkeypatch.setenv("ASTRAI_GEMV", "1")
+    x = torch.randn(1, 64, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(32, 64, device="cuda", dtype=torch.bfloat16)
+    with torch.no_grad():
+        assert "=> gemv" in explain("linear", x, weight)
+        torch.testing.assert_close(
+            linear(x, weight), F.linear(x, weight), rtol=0.02, atol=0.25
+        )
+
+
+@skip_no_gemv
+def test_auto_falls_back_until_end_to_end_gate_passes(monkeypatch):
+    monkeypatch.setenv("ASTRAI_GEMV", "auto")
+    x = torch.randn(1, 1536, device="cuda", dtype=torch.bfloat16)
+    winning = torch.randn(
+        1536,
+        1536,
+        device="cuda",
+        dtype=torch.bfloat16,
+        requires_grad=True,
+    )
+    with torch.no_grad():
+        assert "=> torch" in explain("linear", x, winning)
+        torch.testing.assert_close(linear(x, winning), F.linear(x, winning))
+
+
+@skip_no_gemv
+def test_grad_enabled_and_multirow_always_fall_back(monkeypatch):
+    monkeypatch.setenv("ASTRAI_GEMV", "1")
+    x = torch.randn(1, 1536, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(
+        256, 1536, device="cuda", dtype=torch.bfloat16, requires_grad=True
+    )
+    assert "=> torch" in explain("linear", x, weight)
+    with torch.no_grad():
+        multirow = x.expand(2, -1).contiguous()
+        assert "=> torch" in explain("linear", multirow, weight)
+
+
+@skip_no_gemv
+def test_explicit_gemv_selection_respects_capability(monkeypatch):
+    monkeypatch.setenv("ASTRAI_GEMV", "0")
+    x = torch.randn(1, 1536, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(256, 1536, device="cuda", dtype=torch.bfloat16)
+    with torch.no_grad(), op_backend(linear="gemv"):
+        assert "=> gemv" in explain("linear", x, weight)
+        torch.testing.assert_close(
+            linear(x, weight), F.linear(x, weight), rtol=0.02, atol=0.25
+        )
+
+
+@skip_no_gemv
+def test_dispatched_linear_cuda_graph_replay(monkeypatch):
+    monkeypatch.setenv("ASTRAI_GEMV", "1")
+    x = torch.randn(1, 1536, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(256, 1536, device="cuda", dtype=torch.bfloat16)
+    with torch.no_grad():
+        for _ in range(3):
+            linear(x, weight)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            actual = linear(x, weight)
+        x.copy_(torch.randn_like(x))
+        graph.replay()
+        expected = F.linear(x, weight)
+    torch.testing.assert_close(actual, expected, rtol=0.02, atol=0.25)


### PR DESCRIPTION
_This PR replaces #34 because the original commits were attributed to the wrong GitHub account. The code and validation evidence are unchanged; the commit author and committer are now correctly linked to 0z5a._

## Stack
Base: #42. This PR adds guarded model integration; it does not duplicate the primitive.

## Summary
- route AstrAI `Linear` inference calls through a dedicated backend with `ASTRAI_GEMV=0|1|auto`
- restrict the custom path to no-grad, CUDA, contiguous BF16, M=1, even-K inputs
- preserve PyTorch for training, prefill, unsupported layouts, and unmeasured architectures
- keep the SM89 automatic table empty because the original 1B M=1 experiment did not pass the 3% whole-engine gate

## L20 dispatch benchmark
Exact PR branch with the unchanged #42 kernel, NVIDIA L20 (SM89), BF16, PyTorch 2.11.0+cu128, CUDA 12.8. Ten A-B-B-A rounds; values include Python dispatch overhead.

| shape | F.linear | `auto` fallback | forced GEMV | forced vs F.linear |
|---|---:|---:|---:|---:|
| 256 x 1536 | 0.01108 ms | 0.01370 ms | 0.01123 ms | -1.3% |
| 1536 x 1536 | 0.01096 ms | 0.01355 ms | 0.01129 ms | -3.0% |
| 1536 x 6912 | 0.01239 ms | 0.01370 ms | 0.01134 ms | +9.3% |
| 100000 x 1536 | 0.42083 ms | 0.42101 ms | 0.40596 ms | +3.7% |

This is deliberately not presented as a universal win: dispatcher overhead erases the raw-kernel gain for small M=1 projections, and only the long-K/LM-head cases remain ahead. Consequently `auto` selects no SM89 custom band in this PR. The next optimization must reduce hot-path overhead and use representative common Transformer shapes.

## Validation
- fallback/force/auto routing and diagnostic traces
- dtype, layout, device, grad, bias, and shape guards
- model `Linear` integration and output parity
- full pre-commit suite passed on GPU5