### PR TITLE
perf: extend gemv to small decode batches

### DIFF
--- a/astrai/extension/backend/linear.py
+++ b/astrai/extension/backend/linear.py
@@ -31,10 +31,24 @@ logger = logging.getLogger(__name__)
 
 # Shape keys are (N, K) for Y[M, N] = X[M, K] @ W[N, K].T. A band is
 # automatic only after both the per-shape >=5% and end-to-end decode >=3%
-# gates pass. L20 micro-winners did not produce a stable whole-graph win, so
-# SM89 intentionally has no automatic entries yet. Mode 1 remains available
-# for explicit A/B runs without weakening the default.
-_AUTO_GEMV_SHAPES: dict[tuple[int, int], frozenset[tuple[int, int]]] = {}
+# gates pass and checkpoint greedy output remains stable. M=1 and M=8 remain
+# empty on SM89; the safe M=2/4 bands improve real-engine throughput by
+# 11.8-14.0%.
+_AUTO_GEMV_SHAPES: dict[tuple[int, int], dict[int, frozenset[tuple[int, int]]]] = {
+    (8, 9): {
+        2: frozenset(
+            {
+                (256, 1536),
+                (1536, 1536),
+                (100000, 1536),
+            }
+        ),
+        4: frozenset({(256, 1536), (1536, 1536)}),
+    }
+}
+_AUTO_GEMV_M = frozenset(
+    m for architecture in _AUTO_GEMV_SHAPES.values() for m in architecture
+)
 
 _VALID_MODES = {"0", "1", "auto"}
 _WARNED_MODES: set[str] = set()
@@ -58,7 +72,8 @@ def _axes(
 ) -> dict[str, object]:
     x_shape = tuple(x.shape)
     weight_shape = tuple(weight.shape)
-    single_row = x.ndim == 1 or (x.ndim == 2 and x.shape[0] == 1)
+    m = 1 if x.ndim == 1 else (x.shape[0] if x.ndim == 2 else None)
+    supported_m = m in (1, 2, 4, 8)
     shape_matches = (
         weight.ndim == 2
         and x.ndim in (1, 2)
@@ -84,7 +99,8 @@ def _axes(
         capability=capability,
         n=n,
         k=k,
-        single_row=single_row,
+        m=m,
+        supported_m=supported_m,
         shape_matches=shape_matches,
         same_device=same_device,
         weight_dtype=weight.dtype,
@@ -100,7 +116,7 @@ _SPEC_CAPABLE = (
     & axis("dtype").in_(torch.bfloat16)
     & axis("weight_dtype").in_(torch.bfloat16)
     & axis("grad_enabled").eq(False)
-    & axis("single_row").truthy()
+    & axis("supported_m").truthy()
     & axis("shape_matches").truthy()
     & axis("same_device").truthy()
     & axis("x_contiguous").truthy()
@@ -111,7 +127,8 @@ _SPEC_CAPABLE = (
 
 _SPEC_AUTO = _SPEC_CAPABLE & Spec.of(
     lambda ax: (
-        (ax.get("n"), ax.get("k")) in _AUTO_GEMV_SHAPES.get(ax.get("capability"), ())
+        (ax.get("n"), ax.get("k"))
+        in _AUTO_GEMV_SHAPES.get(ax.get("capability"), {}).get(ax.get("m"), ())
     ),
     "shape is a measured winner for this architecture",
 )
@@ -147,7 +164,7 @@ def _gemv_capable(x: Tensor, weight: Tensor, bias: Optional[Tensor]) -> bool:
         or weight.dtype != torch.bfloat16
         or weight.ndim != 2
         or x.ndim not in (1, 2)
-        or (x.ndim == 2 and x.shape[0] != 1)
+        or (x.ndim == 2 and x.shape[0] not in (1, 2, 4, 8))
         or x.shape[-1] != weight.shape[1]
         or weight.shape[1] % 2 != 0
         or x.device != weight.device
@@ -167,7 +184,10 @@ def _gemv_capable(x: Tensor, weight: Tensor, bias: Optional[Tensor]) -> bool:
 
 def _auto_gemv_shape(x: Tensor, weight: Tensor) -> bool:
     capability = _device_capability(x.get_device())
-    return (weight.shape[0], weight.shape[1]) in _AUTO_GEMV_SHAPES.get(capability, ())
+    m = 1 if x.ndim == 1 else x.shape[0]
+    return (weight.shape[0], weight.shape[1]) in _AUTO_GEMV_SHAPES.get(
+        capability, {}
+    ).get(m, ())
 
 
 def _linear_records() -> list[ImplRecord]:
@@ -219,8 +239,8 @@ def linear(x: Tensor, weight: Tensor, bias: Optional[Tensor] = None) -> Tensor:
     """Apply a linear projection with safe inference-only GEMV dispatch.
 
     ``ASTRAI_GEMV=0`` always uses PyTorch, ``1`` forces GEMV whenever the
-    primitive can safely handle the call, and ``auto`` (the default) uses
-    only architecture/shape bands backed by benchmark evidence.
+    primitive can safely handle an M in ``{1, 2, 4, 8}``, and ``auto`` (the
+    default) uses only architecture/shape bands backed by benchmark evidence.
     """
     # Preserve the shared dispatcher for explicit/context selection and
     # ASTR_OPS diagnostics, while keeping the default per-layer hot path free
@@ -231,6 +251,10 @@ def linear(x: Tensor, weight: Tensor, bias: Optional[Tensor] = None) -> Tensor:
     mode = _gemv_mode()
     if mode == "0" or (mode == "auto" and not _AUTO_GEMV_SHAPES):
         return _torch_linear(x, weight, bias)
+    if mode == "auto":
+        m = 1 if x.ndim == 1 else (x.shape[0] if x.ndim == 2 else None)
+        if m not in _AUTO_GEMV_M:
+            return _torch_linear(x, weight, bias)
     if mode != "0" and _gemv_capable(x, weight, bias):
         if mode == "1" or _auto_gemv_shape(x, weight):
             return _inference_bf16_gemv(x, weight, bias)

--- a/astrai/extension/ops/gemv.py
+++ b/astrai/extension/ops/gemv.py
@@ -12,11 +12,12 @@ def bf16_gemv(
     weight: torch.Tensor,
     bias: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    """Compute ``F.linear(x, weight, bias)`` for a single BF16 input row.
+    """Compute ``F.linear(x, weight, bias)`` for up to eight BF16 rows.
 
-    ``x`` must have shape ``[K]`` or ``[1, K]`` and ``weight`` must be a
-    contiguous row-major ``[N, K]`` tensor. The CUDA kernel accumulates in
-    FP32 and returns BF16. This primitive is inference-only and intentionally
-    performs no fallback or model-level dispatch.
+    ``x`` must have shape ``[K]`` or ``[M, K]`` with M in ``{1, 2, 4, 8}``,
+    and ``weight`` must be a contiguous row-major ``[N, K]`` tensor. The CUDA
+    kernel reuses each weight row across M, accumulates in FP32, and returns
+    BF16. This primitive is inference-only and intentionally performs no
+    fallback or model-level dispatch.
     """
     return get_module("bf16_gemv").bf16_gemv(x, weight, bias)

--- a/csrc/kernels/gemv/bf16_gemv.cu
+++ b/csrc/kernels/gemv/bf16_gemv.cu
@@ -1,4 +1,4 @@
-// Directly callable M=1 BF16 GEMV primitive for decode-time linear layers.
+// Directly callable small-M BF16 GEMV primitive for decode-time linear layers.
 
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
@@ -22,53 +22,84 @@ __device__ __forceinline__ float warp_sum(float value) {
     return value;
 }
 
+template <int Rows>
 __global__ void bf16_gemv_kernel(
     const __nv_bfloat16* __restrict__ x,
     const __nv_bfloat16* __restrict__ weight,
     const __nv_bfloat16* __restrict__ bias,
     __nv_bfloat16* __restrict__ output,
+    int n,
     int k
 ) {
-    const int row = blockIdx.x;
+    const int output_index = blockIdx.x;
     const int lane = threadIdx.x & (kWarpSize - 1);
     const int warp = threadIdx.x / kWarpSize;
     const int pairs = k / 2;
     const auto* x2 = reinterpret_cast<const __nv_bfloat162*>(x);
-    const auto* w2 = reinterpret_cast<const __nv_bfloat162*>(weight) + row * pairs;
+    const auto* w2 =
+        reinterpret_cast<const __nv_bfloat162*>(weight) + output_index * pairs;
 
-    float sum = 0.0f;
+    float sums[Rows] = {};
     for (int pair = threadIdx.x; pair < pairs; pair += blockDim.x) {
-        const __nv_bfloat162 xv = x2[pair];
         const __nv_bfloat162 wv = w2[pair];
-        sum = fmaf(
-            __bfloat162float(__low2bfloat16(xv)),
-            __bfloat162float(__low2bfloat16(wv)),
-            sum
-        );
-        sum = fmaf(
-            __bfloat162float(__high2bfloat16(xv)),
-            __bfloat162float(__high2bfloat16(wv)),
-            sum
-        );
+#pragma unroll
+        for (int row = 0; row < Rows; ++row) {
+            const __nv_bfloat162 xv = x2[row * pairs + pair];
+            sums[row] = fmaf(
+                __bfloat162float(__low2bfloat16(xv)),
+                __bfloat162float(__low2bfloat16(wv)),
+                sums[row]
+            );
+            sums[row] = fmaf(
+                __bfloat162float(__high2bfloat16(xv)),
+                __bfloat162float(__high2bfloat16(wv)),
+                sums[row]
+            );
+        }
     }
 
-    sum = warp_sum(sum);
-    __shared__ float warp_sums[kThreads / kWarpSize];
+    __shared__ float warp_sums[Rows][kThreads / kWarpSize];
+#pragma unroll
+    for (int row = 0; row < Rows; ++row) {
+        sums[row] = warp_sum(sums[row]);
+    }
     if (lane == 0) {
-        warp_sums[warp] = sum;
+#pragma unroll
+        for (int row = 0; row < Rows; ++row) {
+            warp_sums[row][warp] = sums[row];
+        }
     }
     __syncthreads();
 
     if (warp == 0) {
-        sum = lane < (kThreads / kWarpSize) ? warp_sums[lane] : 0.0f;
-        sum = warp_sum(sum);
-        if (lane == 0) {
-            if (bias != nullptr) {
-                sum += __bfloat162float(bias[row]);
+#pragma unroll
+        for (int row = 0; row < Rows; ++row) {
+            float sum =
+                lane < (kThreads / kWarpSize) ? warp_sums[row][lane] : 0.0f;
+            sum = warp_sum(sum);
+            if (lane == 0) {
+                if (bias != nullptr) {
+                    sum += __bfloat162float(bias[output_index]);
+                }
+                output[row * n + output_index] = __float2bfloat16_rn(sum);
             }
-            output[row] = __float2bfloat16_rn(sum);
         }
     }
+}
+
+template <int Rows>
+void launch_bf16_gemv(
+    const __nv_bfloat16* x,
+    const __nv_bfloat16* weight,
+    const __nv_bfloat16* bias,
+    __nv_bfloat16* output,
+    int n,
+    int k,
+    cudaStream_t stream
+) {
+    bf16_gemv_kernel<Rows><<<n, kThreads, 0, stream>>>(
+        x, weight, bias, output, n, k
+    );
 }
 
 torch::Tensor bf16_gemv(
@@ -84,8 +115,8 @@ torch::Tensor bf16_gemv(
         "x and weight must be bf16"
     );
     TORCH_CHECK(
-        x.dim() == 1 || (x.dim() == 2 && x.size(0) == 1),
-        "x must have shape [K] or [1, K]"
+        x.dim() == 1 || x.dim() == 2,
+        "x must have shape [K] or [M, K]"
     );
     TORCH_CHECK(weight.dim() == 2, "weight must have shape [N, K]");
     TORCH_CHECK(x.is_contiguous() && weight.is_contiguous(), "x and weight must be contiguous");
@@ -94,8 +125,13 @@ torch::Tensor bf16_gemv(
         "bf16_gemv is inference-only and does not support autograd"
     );
 
+    const int64_t m = x.dim() == 1 ? 1 : x.size(0);
     const int64_t k = x.size(-1);
     const int64_t n = weight.size(0);
+    TORCH_CHECK(
+        m == 1 || m == 2 || m == 4 || m == 8,
+        "M must be one of 1, 2, 4, or 8"
+    );
     TORCH_CHECK(weight.size(1) == k, "weight K must match x K");
     TORCH_CHECK(k > 0 && n > 0, "N and K must be positive");
     TORCH_CHECK(k % 2 == 0, "K must be even for vectorized bf16 loads");
@@ -121,17 +157,37 @@ torch::Tensor bf16_gemv(
     const auto* properties = at::cuda::getDeviceProperties(x.device().index());
     TORCH_CHECK(properties->major >= 8, "bf16_gemv requires compute capability 8.0+");
     auto stream = at::cuda::getCurrentCUDAStream();
-    auto output = x.dim() == 1
-        ? torch::empty({n}, x.options())
-        : torch::empty({1, n}, x.options());
+    auto output = x.dim() == 1 ? torch::empty({n}, x.options())
+                               : torch::empty({m, n}, x.options());
 
-    bf16_gemv_kernel<<<static_cast<int>(n), kThreads, 0, stream.stream()>>>(
-        reinterpret_cast<const __nv_bfloat16*>(x.data_ptr()),
-        reinterpret_cast<const __nv_bfloat16*>(weight.data_ptr()),
-        bias_ptr,
-        reinterpret_cast<__nv_bfloat16*>(output.data_ptr()),
-        static_cast<int>(k)
-    );
+    const auto* x_ptr = reinterpret_cast<const __nv_bfloat16*>(x.data_ptr());
+    const auto* weight_ptr =
+        reinterpret_cast<const __nv_bfloat16*>(weight.data_ptr());
+    auto* output_ptr = reinterpret_cast<__nv_bfloat16*>(output.data_ptr());
+    const int n_int = static_cast<int>(n);
+    const int k_int = static_cast<int>(k);
+    switch (m) {
+        case 1:
+            launch_bf16_gemv<1>(
+                x_ptr, weight_ptr, bias_ptr, output_ptr, n_int, k_int, stream.stream()
+            );
+            break;
+        case 2:
+            launch_bf16_gemv<2>(
+                x_ptr, weight_ptr, bias_ptr, output_ptr, n_int, k_int, stream.stream()
+            );
+            break;
+        case 4:
+            launch_bf16_gemv<4>(
+                x_ptr, weight_ptr, bias_ptr, output_ptr, n_int, k_int, stream.stream()
+            );
+            break;
+        case 8:
+            launch_bf16_gemv<8>(
+                x_ptr, weight_ptr, bias_ptr, output_ptr, n_int, k_int, stream.stream()
+            );
+            break;
+    }
     C10_CUDA_CHECK(cudaGetLastError());
     return output;
 }
@@ -145,6 +201,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, module) {
         py::arg("x"),
         py::arg("weight"),
         py::arg("bias") = py::none(),
-        "M=1 BF16 GEMV with FP32 accumulation and optional fused bias"
+        "M in {1,2,4,8} BF16 GEMV with FP32 accumulation and optional fused bias"
     );
 }

--- a/docs/developer/cuda_kernels.md
+++ b/docs/developer/cuda_kernels.md
@@ -14,25 +14,39 @@ model linear dispatcher described below.
 | `attn_paged_decode` | `attention/paged_decode.cu` | Paged KV cache decode attention |
 | `attn_paged_prefill` | `attention/paged_prefill.cu` | Paged KV cache prefill attention (ragged batch) |
 | `rotary_emb` | `rotary_emb.cu` | Fused rotary embedding (cos/sin lookup + rotation) |
-| `bf16_gemv` | `gemv/bf16_gemv.cu` | M=1 BF16 linear with FP32 accumulation (sm_80+) |
+| `bf16_gemv` | `gemv/bf16_gemv.cu` | M=1/2/4/8 BF16 linear with FP32 accumulation (sm_80+) |
 | `fp8_ops` | `fp8/ops.cu` | FP8 quantization + tensor-core GEMM (sm_89+) |
 
 ### BF16 GEMV primitive
 
 `astrai.extension.bf16_gemv(x, weight, bias=None)` accepts a contiguous BF16
-input shaped `[K]` or `[1, K]` and row-major weights `[N, K]`. One CTA reduces
-each output row using vectorized `__nv_bfloat162` loads and FP32 accumulation;
-the optional BF16 bias is fused before the BF16 store. The launcher uses the
-current CUDA stream, is CUDA Graph capture-safe, and requires sm_80 or newer.
+input shaped `[K]` or `[M, K]`, with `M` in `{1, 2, 4, 8}`, and row-major
+weights `[N, K]`. One CTA reduces each output row and computes all M results
+together, reusing the weight row across tokens. It uses vectorized
+`__nv_bfloat162` loads and FP32 accumulation; the optional BF16 bias is fused
+before the BF16 store. The launcher uses the current CUDA stream, is CUDA
+Graph capture-safe, and requires sm_80 or newer.
 
 Model `Linear` calls route through the lightweight linear backend. Set
 `ASTRAI_GEMV=0` for an unconditional `F.linear` fallback, `1` to force the
-kernel for any supported M=1 call, or `auto` (the default) to select only
+kernel for any supported M=1/2/4/8 call, or `auto` (the default) to select only
 architecture/shape bands that pass both the per-shape and end-to-end gates.
-No SM89 band is automatic yet: isolated L20 winners did not reach the required
-3% stable whole-graph decode improvement, so `auto` currently falls back to
-PyTorch there. Use `1` only for explicit A/B runs. Training, prefill, and
-unsupported calls always remain on PyTorch.
+M=1 has no automatic SM89 band because isolated winners did not reach the 3%
+whole-graph gate. Measured SM89 small-M bands are enabled as follows:
+
+| M | Automatic `(N, K)` bands | Engine throughput |
+|---:|---|---:|
+| 2 | `(256,1536)`, `(1536,1536)`, `(100000,1536)` | +14.0% |
+| 4 | `(256,1536)`, `(1536,1536)` | +11.8% |
+
+These A→B→B→A results use the real `InferenceEngine`, including scheduler,
+sampling, and CUDA Graph. M=8 stays on PyTorch because its remaining
+greedy-stable winners missed the 3% end-to-end gate. Long-K MLP-down bands are
+also excluded because their valid BF16 error changed a checkpoint greedy
+argmax; the enabled M=2/4 bands matched the baseline greedy output exactly.
+
+Training, prefill, unmeasured architectures, and losing shape bands always
+remain on PyTorch. Use mode `1` only for explicit A/B runs outside this table.
 
 The primitive remains directly callable and deliberately has no internal
 `F.linear` fallback. The model-level backend owns fallback and dispatch policy.

--- a/tests/extension/test_gemv.py
+++ b/tests/extension/test_gemv.py
@@ -31,6 +31,19 @@ def test_bf16_gemv_matches_linear_shape_families(n, k):
 
 
 @skip_no_gemv
+@pytest.mark.parametrize("m", [2, 4, 8])
+@pytest.mark.parametrize("n,k", [(256, 1536), (1536, 1536), (1536, 6912)])
+def test_bf16_gemv_matches_small_decode_batches(m, n, k):
+    torch.manual_seed(19 + m)
+    x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(n, k, device="cuda", dtype=torch.bfloat16)
+    actual = bf16_gemv(x, weight)
+    expected = F.linear(x, weight)
+    assert actual.shape == (m, n)
+    torch.testing.assert_close(actual, expected, rtol=0.02, atol=0.5)
+
+
+@skip_no_gemv
 def test_bf16_gemv_preserves_singleton_batch_and_fuses_bias():
     torch.manual_seed(23)
     x = torch.randn(1, 1536, device="cuda", dtype=torch.bfloat16)
@@ -39,6 +52,17 @@ def test_bf16_gemv_preserves_singleton_batch_and_fuses_bias():
     actual = bf16_gemv(x, weight, bias)
     expected = F.linear(x, weight, bias)
     assert actual.shape == (1, 1536)
+    torch.testing.assert_close(actual, expected, rtol=0.02, atol=0.25)
+
+
+@skip_no_gemv
+def test_bf16_gemv_small_batch_fuses_bias():
+    torch.manual_seed(25)
+    x = torch.randn(4, 1536, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(256, 1536, device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn(256, device="cuda", dtype=torch.bfloat16)
+    actual = bf16_gemv(x, weight, bias)
+    expected = F.linear(x, weight, bias)
     torch.testing.assert_close(actual, expected, rtol=0.02, atol=0.25)
 
 
@@ -73,15 +97,33 @@ def test_bf16_gemv_cuda_graph_replay():
 
 
 @skip_no_gemv
+def test_bf16_gemv_small_batch_cuda_graph_replay():
+    torch.manual_seed(31)
+    x = torch.randn(8, 1536, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(1536, 1536, device="cuda", dtype=torch.bfloat16)
+    for _ in range(3):
+        bf16_gemv(x, weight)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = bf16_gemv(x, weight)
+
+    x.copy_(torch.randn_like(x))
+    graph.replay()
+    expected = F.linear(x, weight)
+    torch.testing.assert_close(actual, expected, rtol=0.02, atol=0.25)
+
+
+@skip_no_gemv
 @pytest.mark.parametrize(
     "make_args,error",
     [
         (
             lambda: (
-                torch.randn(2, 16, device="cuda", dtype=torch.bfloat16),
+                torch.randn(3, 16, device="cuda", dtype=torch.bfloat16),
                 torch.randn(8, 16, device="cuda", dtype=torch.bfloat16),
             ),
-            "shape",
+            "M must",
         ),
         (
             lambda: (

--- a/tests/extension/test_linear_dispatch.py
+++ b/tests/extension/test_linear_dispatch.py
@@ -80,7 +80,20 @@ def test_mode_one_forces_capable_unmeasured_shape(monkeypatch):
 
 
 @skip_no_gemv
-def test_auto_falls_back_until_end_to_end_gate_passes(monkeypatch):
+@pytest.mark.parametrize("m", [2, 4, 8])
+def test_mode_one_dispatches_supported_small_batches(monkeypatch, m):
+    monkeypatch.setenv("ASTRAI_GEMV", "1")
+    x = torch.randn(m, 1536, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(256, 1536, device="cuda", dtype=torch.bfloat16)
+    with torch.no_grad():
+        assert "=> gemv" in explain("linear", x, weight)
+        torch.testing.assert_close(
+            linear(x, weight), F.linear(x, weight), rtol=0.02, atol=0.25
+        )
+
+
+@skip_no_gemv
+def test_auto_m1_falls_back_until_end_to_end_gate_passes(monkeypatch):
     monkeypatch.setenv("ASTRAI_GEMV", "auto")
     x = torch.randn(1, 1536, device="cuda", dtype=torch.bfloat16)
     winning = torch.randn(
@@ -96,7 +109,42 @@ def test_auto_falls_back_until_end_to_end_gate_passes(monkeypatch):
 
 
 @skip_no_gemv
-def test_grad_enabled_and_multirow_always_fall_back(monkeypatch):
+def test_auto_selects_measured_sm89_small_batch_winner(monkeypatch):
+    monkeypatch.setenv("ASTRAI_GEMV", "auto")
+    x = torch.randn(4, 1536, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(256, 1536, device="cuda", dtype=torch.bfloat16)
+    with torch.no_grad():
+        trace = explain("linear", x, weight)
+        if torch.cuda.get_device_capability() == (8, 9):
+            assert "=> auto_gemv" in trace
+        else:
+            assert "=> torch" in trace
+        torch.testing.assert_close(
+            linear(x, weight), F.linear(x, weight), rtol=0.02, atol=0.5
+        )
+
+
+@skip_no_gemv
+@pytest.mark.parametrize(
+    "m,n,k",
+    [
+        (2, 6912, 1536),  # up/gate loses at every measured M
+        (2, 1536, 6912),  # long-K accumulation changed checkpoint greedy output
+        (4, 100000, 1536),  # LM head misses the 5% M=4 gate
+        (4, 1536, 6912),  # long-K accumulation changed checkpoint greedy output
+        (8, 256, 1536),  # remaining M=8 winners miss the 3% end-to-end gate
+    ],
+)
+def test_auto_rejects_measured_small_batch_losers(monkeypatch, m, n, k):
+    monkeypatch.setenv("ASTRAI_GEMV", "auto")
+    x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(n, k, device="cuda", dtype=torch.bfloat16)
+    with torch.no_grad():
+        assert "=> torch" in explain("linear", x, weight)
+
+
+@skip_no_gemv
+def test_grad_enabled_and_unsupported_multirow_always_fall_back(monkeypatch):
     monkeypatch.setenv("ASTRAI_GEMV", "1")
     x = torch.randn(1, 1536, device="cuda", dtype=torch.bfloat16)
     weight = torch.randn(
@@ -104,7 +152,7 @@ def test_grad_enabled_and_multirow_always_fall_back(monkeypatch):
     )
     assert "=> torch" in explain("linear", x, weight)
     with torch.no_grad():
-        multirow = x.expand(2, -1).contiguous()
+        multirow = x.expand(3, -1).contiguous()
         assert "=> torch" in explain("linear", multirow, weight)
 
 


### PR DESCRIPTION
_This PR replaces #35 because the original commits were attributed to the wrong GitHub account. The code and validation evidence are unchanged; the commit author and committer are now correctly linked to 0z5a._

## Stack
Base: #43. This PR extends the primitive and dispatch table from M=1 to small decode batches.

## Summary
- compute M={1,2,4,8} rows per output CTA and reuse each weight row across tokens
- extend correctness, fused-bias, stream, CUDA Graph, and dispatch coverage
- enable only SM89 shape bands that pass both >=5% micro and >=3% whole-engine gates
- retain PyTorch for M=1, M=8, long-K unstable outputs, and every unmeasured band

## L20 whole-engine benchmark
Real `InferenceEngine` A-B-B-A runs on NVIDIA L20 (SM89), including scheduler, sampling, and CUDA Graph:

| M | automatic N x K bands | throughput vs PyTorch |
|---:|---|---:|
| 2 | 256x1536, 1536x1536, 100000x1536 | +14.0% |
| 4 | 256x1536, 1536x1536 | +11.8% |
| 8 | none | did not pass 3% gate |

M=1 remains disabled because the whole-engine result was not stably positive. Long-K MLP-down bands are excluded because valid BF16 accumulation differences changed a checkpoint greedy argmax; enabled M=2/4 bands matched baseline greedy output exactly.

## Validation
- primitive parity for M=1/2/4/8 across projection and MLP shapes
- small-batch fused bias and CUDA Graph replay
- auto-dispatch winner/loser guards and forced-mode coverage
- real checkpoint greedy stability for enabled bands
- full pre-commit suite passed on GPU5