### PR TITLE
feat: add DAPO asymmetric GRPO clipping

### DIFF
--- a/astrai/trainer/strategy.py
+++ b/astrai/trainer/strategy.py
@@ -1,6 +1,8 @@
 """Training strategy implementations with factory pattern."""
 
+import math
 from abc import ABC
+from numbers import Real
 from typing import Callable, Dict, List, Optional, TypedDict, Union
 
 import torch
@@ -553,6 +555,8 @@ class GRPOStrategy(BaseStrategy):
         old_model: nn.Module,
         ref_model: nn.Module,
         clip_eps: float = 0.2,
+        clip_eps_low: Optional[float] = None,
+        clip_eps_high: Optional[float] = None,
         kl_coef: float = 0.01,
         group_size: int = 4,
         **kwargs,
@@ -560,9 +564,32 @@ class GRPOStrategy(BaseStrategy):
         super().__init__(model, device, **kwargs)
         self.old_model = old_model
         self.ref_model = ref_model
-        self.clip_eps = clip_eps
+        self.clip_eps = self._validate_clip_epsilon(clip_eps, "clip_eps", upper=True)
+        self.clip_eps_low = self._validate_clip_epsilon(
+            self.clip_eps if clip_eps_low is None else clip_eps_low,
+            "clip_eps_low",
+            upper=True,
+        )
+        self.clip_eps_high = self._validate_clip_epsilon(
+            self.clip_eps if clip_eps_high is None else clip_eps_high,
+            "clip_eps_high",
+        )
+        if self.clip_eps_high < self.clip_eps_low:
+            raise ValueError(
+                "clip_eps_high must be greater than or equal to clip_eps_low"
+            )
         self.kl_coef = kl_coef
         self.group_size = group_size
+
+    @staticmethod
+    def _validate_clip_epsilon(value: float, name: str, upper: bool = False) -> float:
+        if isinstance(value, bool) or not isinstance(value, Real):
+            raise TypeError(f"{name} must be a real number")
+        value = float(value)
+        if not math.isfinite(value) or value < 0 or (upper and value >= 1):
+            interval = "[0, 1)" if upper else "[0, infinity)"
+            raise ValueError(f"{name} must be finite and in {interval}")
+        return value
 
     def sync_old_model(self):
         """Copy current policy weights to old model."""
@@ -650,7 +677,14 @@ class GRPOStrategy(BaseStrategy):
         ratio = torch.exp(log_ratio)
 
         surr1 = ratio * advantages
-        surr2 = torch.clamp(ratio, 1 - self.clip_eps, 1 + self.clip_eps) * advantages
+        surr2 = (
+            torch.clamp(
+                ratio,
+                1 - self.clip_eps_low,
+                1 + self.clip_eps_high,
+            )
+            * advantages
+        )
         per_token_policy_loss = -torch.min(surr1, surr2)
         token_count = token_masks.sum().clamp(min=1.0)
         policy_loss = (per_token_policy_loss * token_masks).sum() / token_count

--- a/docs/developer/internals.md
+++ b/docs/developer/internals.md
@@ -86,7 +86,9 @@ $$ L_{\text{GRPO}} = -\mathbb{E}_t\left[\min\left(\rho_t A,\; \text{clip}\left(\
 
 Where $\rho_t = \pi_\theta(a_t|s_t) / \pi_{\text{old}}(a_t|s_t)$ is the per-token importance sampling ratio. Advantages are derived from scalar per-response rewards, group-normalized, and broadcast across all response tokens. Only response tokens contribute to the loss.
 
-Parameters: `group_size=4`, `clip_eps=0.2`, `kl_coef=0.01`.
+Parameters: `group_size=4`, `clip_eps=0.2`, `kl_coef=0.01`. Optional
+`clip_eps_low`/`clip_eps_high` values enable DAPO-style asymmetric clipping;
+unset values inherit `clip_eps` for backward-compatible symmetric clipping.
 
 ### MoE Load Balancing
 

--- a/docs/guides/params.md
+++ b/docs/guides/params.md
@@ -141,6 +141,8 @@ with `--optimizer=muon_adamw`.
 | `--label_smoothing` | Label smoothing for cross-entropy loss | 0.0 | `seq`, `sft` |
 | `--group_size` | GRPO/rollout group size | 4 | `grpo`, `online_grpo`, `online_dpo` |
 | `--grpo_clip_eps` | GRPO clipping epsilon | 0.2 | `grpo`, `online_grpo` |
+| `--grpo_clip_eps_low` | Optional lower clip epsilon; defaults to `grpo_clip_eps` | None | `grpo`, `online_grpo` |
+| `--grpo_clip_eps_high` | Optional upper clip epsilon for DAPO Clip-Higher | None | `grpo`, `online_grpo` |
 | `--grpo_kl_coef` | GRPO KL penalty coefficient | 0.01 | `grpo`, `online_grpo` |
 | `--neftune_alpha` | NEFTune noise alpha (0=disabled, typical: 5.0) | 0.0 | `sft` |
 

--- a/docs/guides/training.md
+++ b/docs/guides/training.md
@@ -153,7 +153,12 @@ expectations are over valid response tokens. The KL term regularises
 $\pi_\theta$ towards a frozen reference model (`ref_model`, typically
 the SFT checkpoint).
 
-Parameters: `group_size=4`, `clip_eps=0.2`, `kl_coef=0.01`. External sync of `old_model` weights via `sync_old_model()` between data-generation rounds.
+Parameters: `group_size=4`, `clip_eps=0.2`, `kl_coef=0.01`. The optional
+`clip_eps_low` and `clip_eps_high` parameters replace the symmetric interval
+with $[1-\epsilon_{low}, 1+\epsilon_{high}]$. Leaving both unset preserves the
+existing symmetric objective. DAPO Clip-Higher can be selected explicitly, for
+example with `clip_eps_low=0.2` and `clip_eps_high=0.28`. External sync of
+`old_model` weights via `sync_old_model()` between data-generation rounds.
 
 Keys: `prompts`, `responses`, `masks`, `rewards`.
 

--- a/scripts/tools/train.py
+++ b/scripts/tools/train.py
@@ -306,6 +306,20 @@ _START_METHODS = sorted(START_METHODS)
     help="GRPO clip epsilon.",
 )
 @opt(
+    "--grpo_clip_eps_low",
+    type=float,
+    default=None,
+    group="Algorithm",
+    help="Optional lower GRPO clip epsilon; defaults to --grpo_clip_eps.",
+)
+@opt(
+    "--grpo_clip_eps_high",
+    type=float,
+    default=None,
+    group="Algorithm",
+    help="Optional upper GRPO clip epsilon for DAPO Clip-Higher.",
+)
+@opt(
     "--grpo_kl_coef",
     type=float,
     default=0.01,
@@ -679,6 +693,8 @@ def train(
         "beta": kwargs.pop("dpo_beta"),
         "label_smoothing": kwargs.pop("label_smoothing"),
         "clip_eps": kwargs.pop("grpo_clip_eps"),
+        "clip_eps_low": kwargs.pop("grpo_clip_eps_low"),
+        "clip_eps_high": kwargs.pop("grpo_clip_eps_high"),
         "kl_coef": kwargs.pop("grpo_kl_coef"),
         "group_size": kwargs.pop("group_size"),
     }

--- a/tests/trainer/test_grpo_strategy.py
+++ b/tests/trainer/test_grpo_strategy.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 
+import astrai.trainer.strategy as strategy_module
 from astrai.model.transformer import AutoRegressiveLM
 from astrai.trainer.strategy import GRPOStrategy
 from tests.helpers import FakeExecutor, make_frozen, make_model
@@ -69,6 +70,77 @@ def test_grpo_loss_backward(grpo_strategy):
         for p in strategy.model.parameters()
     )
     assert has_grad
+
+
+def test_grpo_symmetric_clip_is_backward_compatible(grpo_strategy):
+    strategy, _device = grpo_strategy
+    assert strategy.clip_eps == pytest.approx(0.2)
+    assert strategy.clip_eps_low == pytest.approx(0.2)
+    assert strategy.clip_eps_high == pytest.approx(0.2)
+
+
+def test_grpo_dapo_clip_higher_changes_positive_advantage_bound(
+    grpo_strategy, monkeypatch
+):
+    strategy, device = grpo_strategy
+    batch = {
+        "prompts": torch.tensor([[5]], device=device),
+        "responses": torch.tensor([[[6], [7]]], device=device),
+        "masks": torch.ones(1, 2, 1, device=device),
+        "rewards": torch.tensor([[1.0, -1.0]], device=device),
+    }
+    policy_logprobs = torch.log(
+        torch.tensor([[1.25], [0.75]], device=device, dtype=torch.float32)
+    )
+    zeros = torch.zeros_like(policy_logprobs)
+
+    def policy_loss(clip_eps_high):
+        strategy.clip_eps_high = clip_eps_high
+        outputs = iter(
+            [
+                policy_logprobs,
+                zeros,
+                policy_logprobs,
+            ]
+        )
+
+        def fake_get_logprobs(*_args, **_kwargs):
+            return {
+                "logprobs": next(outputs),
+                "aux_loss": None,
+                "router_stats": None,
+            }
+
+        monkeypatch.setattr(strategy_module, "get_logprobs", fake_get_logprobs)
+        return strategy.compute_loss_output(batch)["metrics"]["policy_loss"]
+
+    assert policy_loss(0.2) == pytest.approx(-0.2, abs=1e-6)
+    assert policy_loss(0.28) == pytest.approx(-0.225, abs=1e-6)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"clip_eps_low": 1.0}, "clip_eps_low"),
+        ({"clip_eps_high": float("nan")}, "clip_eps_high"),
+        (
+            {"clip_eps_low": 0.3, "clip_eps_high": 0.2},
+            "greater than or equal",
+        ),
+    ],
+)
+def test_grpo_rejects_invalid_asymmetric_clip(grpo_strategy, kwargs, match):
+    strategy, device = grpo_strategy
+    with pytest.raises(ValueError, match=match):
+        GRPOStrategy(
+            model=strategy.model,
+            device=device,
+            old_model=strategy.old_model,
+            ref_model=strategy.ref_model,
+            clip_eps=0.2,
+            executor=FakeExecutor(),
+            **kwargs,
+        )
 
 
 @pytest.mark.parametrize("model_name", ["ref_model", "old_model"])


### PR DESCRIPTION
## Summary

- add independent lower and upper GRPO clipping epsilons for DAPO Clip-Higher
- preserve the existing symmetric `clip_eps=0.2` behavior when the new options are unset
- expose `--grpo_clip_eps_low` and `--grpo_clip_eps_high` through CLI/YAML configuration
- reject non-finite, negative, inverted, or invalid lower-bound settings
- document the asymmetric objective and the DAPO `0.20/0.28` example

## Objective

The importance-ratio clamp becomes:

```text
clip(rho, 1 - clip_eps_low, 1 + clip_eps_high)
```

Setting both values to `0.2` is exactly the previous GRPO objective. Setting `clip_eps_low=0.2` and `clip_eps_high=0.28` selects the Clip-Higher component described in the [DAPO technical report](https://dapo-sia.github.io/static/pdf/dapo_paper.pdf), without implicitly enabling DAPO's separate dynamic-sampling, token-aggregation, or overlong-reward components.

## L20 microbenchmark

Exact implementation on NVIDIA L20 (SM89), PyTorch 2.11.0+cu128, CUDA 12.8. One loss vector contains 1,048,576 FP32 token ratios/advantages; 30 warmups, then A-B-B-A with 20 samples per path and 100 iterations per sample.

| clamp | median | p90 |
|---|---:|---:|
| symmetric `0.20/0.20` | 0.05333 ms | 0.05406 ms |
| DAPO `0.20/0.28` | 0.05288 ms | 0.05428 ms |

The −0.8% median difference is measurement noise: both paths launch the same operations and differ only in clamp constants. The feature adds no new tensor pass to the GRPO loss hot path.

## Validation

- numerical formula test covers positive upper clipping and unchanged negative lower clipping
- symmetric-default compatibility test
- finite/range/order validation tests
- focused Ruff + pytest: 14 passed
- `CUDA_VISIBLE_DEVICES=5 bash scripts/pre_commit.sh --skip-deps`: **655 passed**
