### PR TITLE
feat: add Dr.GRPO loss normalization

### DIFF
--- a/astrai/trainer/strategy.py
+++ b/astrai/trainer/strategy.py
@@ -1,6 +1,7 @@
 """Training strategy implementations with factory pattern."""
 
 from abc import ABC
+from numbers import Integral
 from typing import Callable, Dict, List, Optional, TypedDict, Union
 
 import torch
@@ -555,6 +556,8 @@ class GRPOStrategy(BaseStrategy):
         clip_eps: float = 0.2,
         kl_coef: float = 0.01,
         group_size: int = 4,
+        loss_variant: str = "grpo",
+        max_completion_length: Optional[int] = None,
         **kwargs,
     ):
         super().__init__(model, device, **kwargs)
@@ -563,6 +566,38 @@ class GRPOStrategy(BaseStrategy):
         self.clip_eps = clip_eps
         self.kl_coef = kl_coef
         self.group_size = group_size
+        if loss_variant not in ("grpo", "dr_grpo"):
+            raise ValueError("loss_variant must be either 'grpo' or 'dr_grpo'")
+        if max_completion_length is not None:
+            if isinstance(max_completion_length, bool) or not isinstance(
+                max_completion_length, Integral
+            ):
+                raise TypeError("max_completion_length must be an integer")
+            if max_completion_length <= 0:
+                raise ValueError("max_completion_length must be positive")
+            max_completion_length = int(max_completion_length)
+        if loss_variant == "dr_grpo" and max_completion_length is None:
+            raise ValueError(
+                "max_completion_length is required when loss_variant='dr_grpo'"
+            )
+        self.loss_variant = loss_variant
+        self.max_completion_length = max_completion_length
+
+    def _group_advantages(self, rewards: Tensor, eps: float) -> Tensor:
+        """Return reward advantages for the configured GRPO objective."""
+        centered_rewards = rewards - rewards.mean(dim=-1, keepdim=True)
+        if self.loss_variant == "dr_grpo":
+            return centered_rewards
+        std = rewards.std(dim=-1, keepdim=True, unbiased=False)
+        return centered_rewards / (std + eps)
+
+    def _policy_loss_normalizer(self, token_masks: Tensor) -> Union[Tensor, int]:
+        """Return the active-token or fixed-budget policy denominator."""
+        if self.loss_variant == "dr_grpo":
+            assert self.max_completion_length is not None
+            batch_size, group_size, _ = token_masks.shape
+            return batch_size * group_size * self.max_completion_length
+        return token_masks.sum().clamp(min=1.0)
 
     def sync_old_model(self):
         """Copy current policy weights to old model."""
@@ -580,6 +615,15 @@ class GRPOStrategy(BaseStrategy):
         rewards = batch["rewards"]
 
         batch_size, group_size, response_len = responses.shape
+        if (
+            self.loss_variant == "dr_grpo"
+            and self.max_completion_length is not None
+            and response_len > self.max_completion_length
+        ):
+            raise ValueError(
+                f"response length {response_len} exceeds max_completion_length "
+                f"{self.max_completion_length}"
+            )
         responses_flat = responses.view(-1, response_len)
         masks_flat = masks.view(-1, response_len)
         prompt_expanded = prompts.unsqueeze(1).repeat(1, group_size, 1).flatten(0, 1)
@@ -637,11 +681,11 @@ class GRPOStrategy(BaseStrategy):
         token_log_probs_ref = token_log_probs_ref.view(batch_size, group_size, -1)
         token_masks = masks_flat.view(batch_size, group_size, -1).float()
 
-        # Group-normalized advantages from scalar per-response rewards.
+        # Scalar per-response advantages: standard GRPO divides centered
+        # rewards by the group standard deviation, while Dr.GRPO deliberately
+        # removes that normalization.
         eps = 1e-8
-        mean = rewards.mean(dim=-1, keepdim=True)
-        std = rewards.std(dim=-1, keepdim=True, unbiased=False)
-        advantages = (rewards - mean) / (std + eps)
+        advantages = self._group_advantages(rewards, eps)
         # Broadcast scalar advantage to every response token: [B, G, 1]
         advantages = advantages.unsqueeze(-1)
 
@@ -653,7 +697,8 @@ class GRPOStrategy(BaseStrategy):
         surr2 = torch.clamp(ratio, 1 - self.clip_eps, 1 + self.clip_eps) * advantages
         per_token_policy_loss = -torch.min(surr1, surr2)
         token_count = token_masks.sum().clamp(min=1.0)
-        policy_loss = (per_token_policy_loss * token_masks).sum() / token_count
+        policy_normalizer = self._policy_loss_normalizer(token_masks)
+        policy_loss = (per_token_policy_loss * token_masks).sum() / policy_normalizer
 
         # KL penalty to frozen reference model with k1 estimator (non-negative):
         # k1 = π_ref / π_θ - log(π_ref / π_θ) - 1, where π_ref / π_θ = exp(log_ref - log_policy).

--- a/astrai/trainer/train_context.py
+++ b/astrai/trainer/train_context.py
@@ -279,6 +279,12 @@ class TrainContextBuilder:
     def _create_strategy(self, context: TrainContext, executor: BaseExecutor) -> dict:
         cfg = self.config
         kwargs = dict(cfg.strategy_kwargs)
+        if (
+            cfg.strategy == "online_grpo"
+            and kwargs.get("loss_variant") == "dr_grpo"
+            and kwargs.get("max_completion_length") is None
+        ):
+            kwargs["max_completion_length"] = cfg.rollout_max_tokens
         kwargs.setdefault("moe_aux_loss_coef", cfg.moe_aux_loss_coef)
         if cfg.strategy in ("dpo", "grpo", "online_grpo", "online_dpo"):
             kwargs["ref_model"] = create_ref_model(

--- a/docs/developer/internals.md
+++ b/docs/developer/internals.md
@@ -88,6 +88,12 @@ Where $\rho_t = \pi_\theta(a_t|s_t) / \pi_{\text{old}}(a_t|s_t)$ is the per-toke
 
 Parameters: `group_size=4`, `clip_eps=0.2`, `kl_coef=0.01`.
 
+`loss_variant="dr_grpo"` removes reward standard-deviation normalization and
+uses `batch_size * group_size * max_completion_length` as the fixed policy-loss
+denominator. The per-token scale therefore stays fixed when the number of valid
+response tokens changes across batches. The default `loss_variant="grpo"`
+preserves the existing objective exactly.
+
 ### MoE Load Balancing
 
 MoE layers add a differentiable load-balancing term based on mean router probabilities and top-k expert assignment frequency. The training objective is:

--- a/docs/guides/params.md
+++ b/docs/guides/params.md
@@ -142,6 +142,8 @@ with `--optimizer=muon_adamw`.
 | `--group_size` | GRPO/rollout group size | 4 | `grpo`, `online_grpo`, `online_dpo` |
 | `--grpo_clip_eps` | GRPO clipping epsilon | 0.2 | `grpo`, `online_grpo` |
 | `--grpo_kl_coef` | GRPO KL penalty coefficient | 0.01 | `grpo`, `online_grpo` |
+| `--grpo_loss_variant` | Objective variant (`grpo` or `dr_grpo`) | `grpo` | `grpo`, `online_grpo` |
+| `--grpo_max_completion_length` | Fixed completion budget used by Dr.GRPO; online mode defaults to `rollout_max_tokens` | None | `grpo`, `online_grpo` |
 | `--neftune_alpha` | NEFTune noise alpha (0=disabled, typical: 5.0) | 0.0 | `sft` |
 
 ### Online Rollout

--- a/docs/guides/training.md
+++ b/docs/guides/training.md
@@ -157,6 +157,23 @@ Parameters: `group_size=4`, `clip_eps=0.2`, `kl_coef=0.01`. External sync of `ol
 
 Keys: `prompts`, `responses`, `masks`, `rewards`.
 
+Set `loss_variant="dr_grpo"` to use the two bias-removal changes from
+[Understanding R1-Zero-Like Training](https://arxiv.org/abs/2503.20783):
+
+$$
+A_i^{\text{Dr.GRPO}} = r_i - \mu, \qquad
+L_{\text{policy}} = \frac{1}{BG L_{\max}}
+\sum_{i=1}^{B}\sum_{j=1}^{G}\sum_{t=1}^{L_{\max}}
+m_{ijt}\,\ell_{ijt}.
+$$
+
+Unlike standard GRPO, this variant does not divide centered rewards by their
+group standard deviation and does not divide policy loss by the number of valid
+tokens. `max_completion_length` is therefore required as a fixed generation
+budget; online training uses `rollout_max_tokens` when it is not set explicitly.
+The KL regularizer remains independently configurable. Set `kl_coef=0` to match
+the paper's no-KL recipe.
+
 ### Online Rollout
 
 `online_grpo` and `online_dpo` use the respective GRPO and DPO strategies with

--- a/scripts/tools/train.py
+++ b/scripts/tools/train.py
@@ -313,6 +313,23 @@ _START_METHODS = sorted(START_METHODS)
     help="GRPO KL penalty coefficient.",
 )
 @opt(
+    "--grpo_loss_variant",
+    type=click.Choice(["grpo", "dr_grpo"]),
+    default="grpo",
+    group="Algorithm",
+    help="GRPO objective variant.",
+)
+@opt(
+    "--grpo_max_completion_length",
+    type=click.IntRange(min=1),
+    default=None,
+    group="Algorithm",
+    help=(
+        "Fixed Dr.GRPO completion budget; online Dr.GRPO defaults to "
+        "--rollout_max_tokens."
+    ),
+)
+@opt(
     "--label_smoothing",
     type=float,
     default=0.0,
@@ -681,6 +698,8 @@ def train(
         "clip_eps": kwargs.pop("grpo_clip_eps"),
         "kl_coef": kwargs.pop("grpo_kl_coef"),
         "group_size": kwargs.pop("group_size"),
+        "loss_variant": kwargs.pop("grpo_loss_variant"),
+        "max_completion_length": kwargs.pop("grpo_max_completion_length"),
     }
 
     rollout_interval = kwargs.pop("rollout_interval", 512)

--- a/tests/trainer/test_grpo_strategy.py
+++ b/tests/trainer/test_grpo_strategy.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 
+import astrai.trainer.strategy as strategy_module
 from astrai.model.transformer import AutoRegressiveLM
 from astrai.trainer.strategy import GRPOStrategy
 from tests.helpers import FakeExecutor, make_frozen, make_model
@@ -69,6 +70,103 @@ def test_grpo_loss_backward(grpo_strategy):
         for p in strategy.model.parameters()
     )
     assert has_grad
+
+
+def test_grpo_default_advantages_remain_group_standardized(grpo_strategy):
+    strategy, device = grpo_strategy
+    rewards = torch.tensor([[1.0, 2.0, 5.0]], device=device)
+    advantages = strategy._group_advantages(rewards, eps=1e-8)
+    expected = (rewards - rewards.mean(dim=-1, keepdim=True)) / rewards.std(
+        dim=-1, keepdim=True, unbiased=False
+    )
+    torch.testing.assert_close(advantages, expected)
+
+
+def test_dr_grpo_uses_centered_rewards_and_fixed_completion_budget(
+    grpo_strategy, monkeypatch
+):
+    base_strategy, device = grpo_strategy
+    strategy = GRPOStrategy(
+        model=base_strategy.model,
+        device=device,
+        old_model=base_strategy.old_model,
+        ref_model=base_strategy.ref_model,
+        clip_eps=0.2,
+        kl_coef=0.0,
+        group_size=2,
+        loss_variant="dr_grpo",
+        max_completion_length=8,
+        executor=FakeExecutor(),
+    )
+    batch = {
+        "prompts": torch.tensor([[5]], device=device),
+        "responses": torch.tensor([[[6, 7, 8, 9], [10, 0, 0, 0]]], device=device),
+        "masks": torch.tensor(
+            [[[1, 1, 1, 1], [1, 0, 0, 0]]], device=device, dtype=torch.bool
+        ),
+        "rewards": torch.tensor([[4.0, 1.0]], device=device),
+    }
+    zeros = torch.zeros(2, 4, device=device)
+
+    def fake_get_logprobs(*_args, **_kwargs):
+        return {"logprobs": zeros, "aux_loss": None, "router_stats": None}
+
+    monkeypatch.setattr(strategy_module, "get_logprobs", fake_get_logprobs)
+    output = strategy.compute_loss_output(batch)
+
+    torch.testing.assert_close(
+        strategy._group_advantages(batch["rewards"], eps=1e-8),
+        torch.tensor([[1.5, -1.5]], device=device),
+    )
+    # Sum of masked per-token losses is -(4 * 1.5 - 1 * 1.5) = -4.5;
+    # Dr.GRPO divides by B * G * fixed_budget = 1 * 2 * 8 = 16.
+    assert output["metrics"]["policy_loss"] == pytest.approx(-4.5 / 16, abs=1e-6)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error", "match"),
+    [
+        ({"loss_variant": "unknown"}, ValueError, "loss_variant"),
+        ({"loss_variant": "dr_grpo"}, ValueError, "max_completion_length"),
+        (
+            {"loss_variant": "dr_grpo", "max_completion_length": 0},
+            ValueError,
+            "positive",
+        ),
+        (
+            {"loss_variant": "dr_grpo", "max_completion_length": 4.5},
+            TypeError,
+            "integer",
+        ),
+    ],
+)
+def test_grpo_rejects_invalid_loss_variant_config(grpo_strategy, kwargs, error, match):
+    strategy, device = grpo_strategy
+    with pytest.raises(error, match=match):
+        GRPOStrategy(
+            model=strategy.model,
+            device=device,
+            old_model=strategy.old_model,
+            ref_model=strategy.ref_model,
+            executor=FakeExecutor(),
+            **kwargs,
+        )
+
+
+def test_dr_grpo_rejects_response_longer_than_fixed_budget(grpo_strategy):
+    base_strategy, device = grpo_strategy
+    strategy = GRPOStrategy(
+        model=base_strategy.model,
+        device=device,
+        old_model=base_strategy.old_model,
+        ref_model=base_strategy.ref_model,
+        loss_variant="dr_grpo",
+        max_completion_length=3,
+        executor=FakeExecutor(),
+    )
+    batch = _make_batch(batch_size=1, group_size=2, response_len=4, device=device)
+    with pytest.raises(ValueError, match="exceeds max_completion_length"):
+        strategy.compute_loss_output(batch)
 
 
 @pytest.mark.parametrize("model_name", ["ref_model", "old_model"])

--- a/tests/trainer/test_online_e2e.py
+++ b/tests/trainer/test_online_e2e.py
@@ -81,6 +81,16 @@ _ONLINE_STRATEGIES = [
         {"clip_eps": 0.2, "kl_coef": 0.01, "group_size": 2},
         id="grpo",
     ),
+    pytest.param(
+        "online_grpo",
+        {
+            "clip_eps": 0.2,
+            "kl_coef": 0.0,
+            "group_size": 2,
+            "loss_variant": "dr_grpo",
+        },
+        id="dr-grpo",
+    ),
     pytest.param("online_dpo", {"beta": 0.1, "group_size": 2}, id="dpo"),
 ]
 


### PR DESCRIPTION
## Summary

- add an opt-in `dr_grpo` loss variant
- remove group reward standard-deviation normalization in that variant
- normalize policy loss by the fixed `batch_size * group_size * max_completion_length` budget
- derive the online fixed budget from `rollout_max_tokens` when it is not set explicitly
- keep the existing `grpo` objective and KL regularizer behavior unchanged

## Why

Dr.GRPO identifies two normalization choices that can bias R1-Zero-style training: reward scaling by the within-group standard deviation and response-dependent policy-loss normalization. This change exposes both corrections as one explicit objective variant while preserving the current default exactly.

For a paper-faithful no-KL recipe, use `loss_variant="dr_grpo"`, a fixed `max_completion_length`, and `kl_coef=0`. Offline GRPO requires the fixed completion budget explicitly; online GRPO defaults it to `rollout_max_tokens`.

Primary reference: [Understanding R1-Zero-Like Training: A Critical Perspective](https://arxiv.org/abs/2503.20783).

## L20 microbenchmark

Exact commit: `ffa8520de2c6ac0494702e5eb6d7c9bb33d30536`

NVIDIA L20, FP32 formula path, `B=256`, `G=8`, response tensor length `512`, fixed budget `1024`, 1,048,576 response slots and 785,863 valid tokens. Twenty alternating samples, 200 iterations per sample, CUDA-event timing after warmup.

| objective | median | p90 |
|---|---:|---:|
| standard GRPO | 0.128371 ms | 0.133325 ms |
| Dr.GRPO | 0.082757 ms | 0.090342 ms |

Dr.GRPO was 35.53% faster in this isolated formula microbenchmark because it removes the reward-std and dynamic token-count reductions. This is not an end-to-end training throughput claim; model forward/backward still dominate real training.

## Validation

- `python -m pytest -q`: **658 passed** on NVIDIA L20 GPU5
- focused GRPO, CLI, and online rollout suite: **19 passed**
- Ruff format and lint checks passed
- tests cover default formula compatibility, exact Dr.GRPO numerics with variable masks, fixed-budget validation, invalid configuration, and online budget derivation

## Compatibility

The default remains `loss_variant="grpo"`; existing configs and loss numerics are unchanged.