### PR TITLE
feat(training): emit rank-local admission telemetry

### DIFF
--- a/astrai/config/train_config.py
+++ b/astrai/config/train_config.py
@@ -63,6 +63,12 @@ class TrainConfig(BaseConfig):
         val_step (int): Number of optimizer steps between validation runs. Defaults to 1000.
         neftune_alpha (float): NEFTune noise alpha, 0=disabled, typical: 5.0. Defaults to 0.0.
         moe_aux_loss_coef (float): Weight applied to the MoE load-balancing loss. Defaults to 0.01.
+        training_telemetry_enabled (bool): Emit rank-local structured training work traces. Defaults to False.
+        training_cost_flops_per_token (float): Optional FLOP proxy coefficient. Zero reports the estimate as unknown. Defaults to 0.0.
+        training_cost_activation_bytes_per_token (int): Optional activation-memory proxy coefficient. Zero reports the estimate as unknown. Defaults to 0.
+        training_cost_communication_bytes_per_token (int): Optional communication proxy coefficient. Zero reports the estimate as unknown. Defaults to 0.
+        training_cost_duration_ms_per_token (float): Optional duration proxy coefficient. Zero reports the estimate as unknown. Defaults to 0.0.
+        training_cost_confidence (float): Confidence attached to configured cost proxies, in [0, 1]. Defaults to 1.0.
         rollout_interval (int): Number of optimizer steps between online rollouts. Defaults to 512.
         rollout_max_policy_lag (Optional[int]): Maximum accepted gap between rollout and live policy versions. None derives ``rollout_interval - 1``. Defaults to None.
         rollout_temperature (float): Sampling temperature for online rollout. Defaults to 0.7.
@@ -117,6 +123,13 @@ class TrainConfig(BaseConfig):
     val_step: int = 1000
     neftune_alpha: float = 0.0
     moe_aux_loss_coef: float = 0.01
+
+    training_telemetry_enabled: bool = False
+    training_cost_flops_per_token: float = 0.0
+    training_cost_activation_bytes_per_token: int = 0
+    training_cost_communication_bytes_per_token: int = 0
+    training_cost_duration_ms_per_token: float = 0.0
+    training_cost_confidence: float = 1.0
 
     rollout_interval: int = 512
     rollout_max_policy_lag: Optional[int] = None
@@ -194,11 +207,24 @@ class TrainConfig(BaseConfig):
         return v
 
     @field_validator(
-        "rollout_top_k", "num_workers", "neftune_alpha", "moe_aux_loss_coef"
+        "rollout_top_k",
+        "num_workers",
+        "neftune_alpha",
+        "moe_aux_loss_coef",
+        "training_cost_flops_per_token",
+        "training_cost_activation_bytes_per_token",
+        "training_cost_communication_bytes_per_token",
+        "training_cost_duration_ms_per_token",
     )
     def _validate_non_negative(cls, v):
         if v < 0:
             raise ValueError(f"must be non-negative, got {v}")
+        return v
+
+    @field_validator("training_cost_confidence")
+    def _validate_training_cost_confidence(cls, v: float) -> float:
+        if not 0 <= v <= 1:
+            raise ValueError(f"training_cost_confidence must be in [0, 1], got {v}")
         return v
 
     @field_validator("rollout_max_policy_lag")

--- a/astrai/trainer/__init__.py
+++ b/astrai/trainer/__init__.py
@@ -5,17 +5,29 @@ from astrai.trainer.train_callback import (
     TrainCallback,
 )
 from astrai.trainer.trainer import Trainer
+from astrai.trainer.training_telemetry import (
+    BatchTokenCounts,
+    CostEstimate,
+    TokenCostModel,
+    TrainingTelemetry,
+    TrainingTrace,
+    WorkItem,
+    count_batch_tokens,
+)
 
 __all__ = [
-    # Main trainer
-    "Trainer",
-    # Strategy factory
-    "StrategyFactory",
-    "BaseStrategy",
-    # Scheduler factory
-    "SchedulerFactory",
     "BaseScheduler",
-    # Callback factory
-    "TrainCallback",
+    "BaseStrategy",
+    "BatchTokenCounts",
     "CallbackFactory",
+    "CostEstimate",
+    "SchedulerFactory",
+    "StrategyFactory",
+    "TokenCostModel",
+    "TrainCallback",
+    "Trainer",
+    "TrainingTelemetry",
+    "TrainingTrace",
+    "WorkItem",
+    "count_batch_tokens",
 ]

--- a/astrai/trainer/train_context.py
+++ b/astrai/trainer/train_context.py
@@ -32,6 +32,11 @@ from astrai.tokenize import AutoTokenizer
 from astrai.trainer.metric_util import GradSNRTracker
 from astrai.trainer.rollout import RolloutGenerator, RolloutRunner
 from astrai.trainer.strategy import BaseStrategy, StrategyFactory
+from astrai.trainer.training_telemetry import (
+    NullTrainingTelemetry,
+    TrainingTelemetry,
+    create_training_telemetry,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +60,9 @@ class TrainContext:
     grad_snr_tracker: GradSNRTracker = field(default_factory=GradSNRTracker)
     val_dataloader: Optional[DataLoader] = field(default=None)
     val_loss: Optional[float] = field(default=None)
+    training_telemetry: TrainingTelemetry | NullTrainingTelemetry = field(
+        default_factory=NullTrainingTelemetry
+    )
 
     world_size: int = field(default=1)
     rank: int = field(default=0)
@@ -182,6 +190,7 @@ class TrainContextBuilder:
             consumed_samples=state.consumed_samples,
             checkpoint=state.checkpoint,
             param_path=self._param_path,
+            training_telemetry=create_training_telemetry(self.config),
         )
 
     def _prepare_model(

--- a/astrai/trainer/trainer.py
+++ b/astrai/trainer/trainer.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 import torch.distributed as dist
 
 from astrai.config import TrainConfig
-from astrai.parallel.setup import spawn_parallel_fn
+from astrai.parallel.setup import get_current_device, spawn_parallel_fn
 from astrai.signal_handler import (
     register_signal_handlers,
     unregister_signal_handlers,
@@ -80,7 +80,21 @@ class Trainer:
                 for batch in context.dataloader:
                     if context.stop_requested:
                         break
-                    with executor.accumulate(context.model):
+                    with (
+                        executor.accumulate(context.model),
+                        context.training_telemetry.observe_batch(
+                            batch,
+                            strategy=context.config.strategy,
+                            rank=context.rank,
+                            world_size=context.world_size,
+                            epoch=context.epoch,
+                            optimizer_step=context.optimizer_step,
+                            policy_version=getattr(
+                                context.strategy, "policy_version", None
+                            ),
+                            device=get_current_device(),
+                        ),
+                    ):
                         self._call_callbacks("on_batch_begin", context)
                         loss_output = context.strategy(batch)
                         context.loss = loss_output["loss"].item()

--- a/astrai/trainer/training_telemetry.py
+++ b/astrai/trainer/training_telemetry.py
@@ -1,0 +1,409 @@
+"""Rank-local observability for future training admission decisions.
+
+The telemetry path deliberately does not choose a rank or synchronize workers.  It
+turns each local microbatch into a :class:`WorkItem`, tracks its token pressure,
+and emits one structured completion trace that a later scheduler can consume.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from typing import Any, Protocol
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class BatchTokenCounts:
+    """Non-overlapping token counts used by one training microbatch."""
+
+    input_tokens: int
+    output_tokens: int = 0
+
+    @property
+    def total_tokens(self) -> int:
+        return self.input_tokens + self.output_tokens
+
+
+@dataclass(frozen=True)
+class CostEstimate:
+    """A token-exact estimate with optional calibrated cost proxies."""
+
+    tokens: int
+    flops: float | None
+    activation_bytes: int | None
+    communication_bytes: int | None
+    expected_duration_ms: float | None
+    confidence: float
+
+
+@dataclass(frozen=True)
+class TokenCostModel:
+    """Convert exact token counts into explicitly configured cost proxies.
+
+    A zero coefficient means "unknown" and is reported as ``None`` rather than a
+    fabricated zero-cost estimate.
+    """
+
+    flops_per_token: float = 0.0
+    activation_bytes_per_token: int = 0
+    communication_bytes_per_token: int = 0
+    duration_ms_per_token: float = 0.0
+    confidence: float = 1.0
+
+    def __post_init__(self) -> None:
+        coefficients = (
+            self.flops_per_token,
+            self.activation_bytes_per_token,
+            self.communication_bytes_per_token,
+            self.duration_ms_per_token,
+        )
+        if any(value < 0 for value in coefficients):
+            raise ValueError("training cost coefficients must be non-negative")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("training cost confidence must be in [0, 1]")
+
+    def estimate(self, tokens: int) -> CostEstimate:
+        if tokens < 0:
+            raise ValueError("tokens must be non-negative")
+        return CostEstimate(
+            tokens=tokens,
+            flops=(tokens * self.flops_per_token if self.flops_per_token else None),
+            activation_bytes=(
+                tokens * self.activation_bytes_per_token
+                if self.activation_bytes_per_token
+                else None
+            ),
+            communication_bytes=(
+                tokens * self.communication_bytes_per_token
+                if self.communication_bytes_per_token
+                else None
+            ),
+            expected_duration_ms=(
+                tokens * self.duration_ms_per_token
+                if self.duration_ms_per_token
+                else None
+            ),
+            confidence=self.confidence,
+        )
+
+
+@dataclass(frozen=True)
+class WorkItem:
+    """One rank-local training unit observed without changing its placement."""
+
+    work_id: str
+    phase: str
+    strategy: str
+    rank: int
+    world_size: int
+    epoch: int
+    optimizer_step: int
+    microbatch: int
+    input_tokens: int
+    output_tokens: int
+    cost: CostEstimate
+    policy_version: int | None = None
+    estimation_error: str | None = None
+
+
+@dataclass(frozen=True)
+class TrainingTrace:
+    """Structured completion record for a :class:`WorkItem`."""
+
+    work_item: WorkItem
+    status: str
+    host_duration_ms: float
+    peak_hbm_bytes: int
+    inflight_tokens_at_start: int
+    inflight_tokens_at_end: int
+    error_type: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "event": "training_work_item_completed",
+            **asdict(self),
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
+
+
+def _numel(value: Any) -> int:
+    if isinstance(value, torch.Tensor):
+        return value.numel()
+    if isinstance(value, Mapping):
+        return sum(_numel(item) for item in value.values())
+    if isinstance(value, (list, tuple)):
+        return sum(_numel(item) for item in value)
+    return 1 if value is not None else 0
+
+
+def _mask_tokens(mask: Any) -> int:
+    if isinstance(mask, torch.Tensor):
+        return int(mask.detach().to(dtype=torch.int64).sum().item())
+    if isinstance(mask, Mapping):
+        return sum(_mask_tokens(item) for item in mask.values())
+    if isinstance(mask, (list, tuple)):
+        return sum(_mask_tokens(item) for item in mask)
+    return int(bool(mask))
+
+
+def _sequence_tokens(value: Any, mask: Any | None) -> int:
+    return _mask_tokens(mask) if mask is not None else _numel(value)
+
+
+def _group_size(batch: Mapping[str, Any]) -> int:
+    responses = batch.get("responses")
+    if isinstance(responses, torch.Tensor) and responses.ndim >= 3:
+        return int(responses.shape[1])
+    if isinstance(responses, (list, tuple)) and responses:
+        first = responses[0]
+        return len(first) if isinstance(first, (list, tuple)) else 1
+    masks = batch.get("masks")
+    if isinstance(masks, torch.Tensor) and masks.ndim >= 3:
+        return int(masks.shape[1])
+    return 1
+
+
+def count_batch_tokens(batch: Mapping[str, Any], *, strategy: str) -> BatchTokenCounts:
+    """Count tokens that participate in the strategy's model forwards.
+
+    Prompt tokens in GRPO are expanded once per response group, matching the
+    strategy implementation. DPO counts both chosen and rejected sequences.
+    Sequence/SFT training counts attention-valid inputs and never double-counts
+    labels or the loss mask.
+    """
+
+    if "chosen" in batch and "rejected" in batch:
+        chosen = _sequence_tokens(batch["chosen"], batch.get("chosen_attention_mask"))
+        rejected = _sequence_tokens(
+            batch["rejected"], batch.get("rejected_attention_mask")
+        )
+        return BatchTokenCounts(input_tokens=chosen + rejected)
+
+    if "prompts" in batch and "responses" in batch:
+        prompts = _sequence_tokens(batch["prompts"], batch.get("prompt_mask"))
+        responses = _sequence_tokens(batch["responses"], batch.get("masks"))
+        return BatchTokenCounts(
+            input_tokens=prompts * _group_size(batch),
+            output_tokens=responses,
+        )
+
+    if "input_ids" in batch:
+        return BatchTokenCounts(
+            input_tokens=_sequence_tokens(
+                batch["input_ids"], batch.get("attention_mask")
+            )
+        )
+
+    raise ValueError(f"cannot estimate tokens for {strategy!r} batch")
+
+
+class MemoryProbe(Protocol):
+    def start(self, device: str | torch.device | None) -> None: ...
+
+    def stop(self) -> int: ...
+
+
+class _CudaPeakMemoryProbe:
+    def __init__(self) -> None:
+        self._device: torch.device | None = None
+
+    def start(self, device: str | torch.device | None) -> None:
+        self._device = None
+        if device is None:
+            return
+        resolved = torch.device(device)
+        if resolved.type != "cuda" or not torch.cuda.is_available():
+            return
+        self._device = resolved
+        torch.cuda.reset_peak_memory_stats(resolved)
+
+    def stop(self) -> int:
+        if self._device is None:
+            return 0
+        return int(torch.cuda.max_memory_allocated(self._device))
+
+
+TraceSink = Callable[[TrainingTrace], None]
+
+
+class TrainingTelemetry:
+    """Observe local microbatches and expose their instantaneous token pressure."""
+
+    def __init__(
+        self,
+        *,
+        cost_model: TokenCostModel | None = None,
+        sink: TraceSink | None = None,
+        clock: Callable[[], float] = time.perf_counter,
+        memory_probe: MemoryProbe | None = None,
+    ) -> None:
+        self.cost_model = cost_model or TokenCostModel()
+        self._sink = sink
+        self._clock = clock
+        self._memory_probe = memory_probe or _CudaPeakMemoryProbe()
+        self._lock = threading.Lock()
+        self._next_microbatch = 0
+        self._inflight_tokens = 0
+
+    @property
+    def inflight_tokens(self) -> int:
+        with self._lock:
+            return self._inflight_tokens
+
+    def _new_work_item(
+        self,
+        batch: Mapping[str, Any],
+        *,
+        strategy: str,
+        rank: int,
+        world_size: int,
+        epoch: int,
+        optimizer_step: int,
+        policy_version: int | None,
+    ) -> tuple[WorkItem, int]:
+        estimation_error = None
+        try:
+            counts = count_batch_tokens(batch, strategy=strategy)
+        except Exception as exc:  # noqa: BLE001 - telemetry must fail open
+            counts = BatchTokenCounts(0, 0)
+            estimation_error = type(exc).__name__
+            logger.warning("training telemetry token estimation failed: %s", exc)
+
+        cost = self.cost_model.estimate(counts.total_tokens)
+        with self._lock:
+            microbatch = self._next_microbatch
+            self._next_microbatch += 1
+            self._inflight_tokens += cost.tokens
+            inflight = self._inflight_tokens
+
+        return (
+            WorkItem(
+                work_id=(f"train-r{rank}-e{epoch}-s{optimizer_step}-m{microbatch}"),
+                phase="train",
+                strategy=strategy,
+                rank=rank,
+                world_size=world_size,
+                epoch=epoch,
+                optimizer_step=optimizer_step,
+                microbatch=microbatch,
+                input_tokens=counts.input_tokens,
+                output_tokens=counts.output_tokens,
+                cost=cost,
+                policy_version=policy_version,
+                estimation_error=estimation_error,
+            ),
+            inflight,
+        )
+
+    def _start_memory_probe(self, device: str | torch.device | None) -> None:
+        try:
+            self._memory_probe.start(device)
+        except Exception as exc:  # noqa: BLE001 - telemetry must fail open
+            logger.warning("training telemetry HBM probe start failed: %s", exc)
+
+    def _stop_memory_probe(self) -> int:
+        try:
+            return self._memory_probe.stop()
+        except Exception as exc:  # noqa: BLE001 - telemetry must fail open
+            logger.warning("training telemetry HBM probe stop failed: %s", exc)
+            return 0
+
+    def _emit(self, trace: TrainingTrace) -> None:
+        logger.info("training_telemetry %s", trace.to_json())
+        if self._sink is None:
+            return
+        try:
+            self._sink(trace)
+        except Exception:
+            logger.exception("training telemetry sink failed")
+
+    @contextmanager
+    def observe_batch(
+        self,
+        batch: Mapping[str, Any],
+        *,
+        strategy: str,
+        rank: int,
+        world_size: int,
+        epoch: int,
+        optimizer_step: int,
+        policy_version: int | None = None,
+        device: str | torch.device | None = None,
+    ) -> Iterator[WorkItem]:
+        work_item, inflight_at_start = self._new_work_item(
+            batch,
+            strategy=strategy,
+            rank=rank,
+            world_size=world_size,
+            epoch=epoch,
+            optimizer_step=optimizer_step,
+            policy_version=policy_version,
+        )
+        self._start_memory_probe(device)
+        started_at = self._clock()
+        status = "ok"
+        error_type = None
+        try:
+            yield work_item
+        except BaseException as exc:
+            status = "error"
+            error_type = type(exc).__name__
+            raise
+        finally:
+            duration_ms = max(0.0, (self._clock() - started_at) * 1000.0)
+            peak_hbm_bytes = self._stop_memory_probe()
+            with self._lock:
+                self._inflight_tokens -= work_item.cost.tokens
+                inflight_at_end = self._inflight_tokens
+            self._emit(
+                TrainingTrace(
+                    work_item=work_item,
+                    status=status,
+                    host_duration_ms=duration_ms,
+                    peak_hbm_bytes=peak_hbm_bytes,
+                    inflight_tokens_at_start=inflight_at_start,
+                    inflight_tokens_at_end=inflight_at_end,
+                    error_type=error_type,
+                )
+            )
+
+
+class NullTrainingTelemetry:
+    """Minimal disabled implementation that never inspects the batch."""
+
+    @property
+    def inflight_tokens(self) -> int:
+        return 0
+
+    @contextmanager
+    def observe_batch(self, batch: Any, **kwargs: Any) -> Iterator[None]:
+        yield None
+
+
+def create_training_telemetry(config: Any) -> TrainingTelemetry | NullTrainingTelemetry:
+    if not config.training_telemetry_enabled:
+        return NullTrainingTelemetry()
+    return TrainingTelemetry(
+        cost_model=TokenCostModel(
+            flops_per_token=config.training_cost_flops_per_token,
+            activation_bytes_per_token=(
+                config.training_cost_activation_bytes_per_token
+            ),
+            communication_bytes_per_token=(
+                config.training_cost_communication_bytes_per_token
+            ),
+            duration_ms_per_token=config.training_cost_duration_ms_per_token,
+            confidence=config.training_cost_confidence,
+        )
+    )

--- a/docs/notebooks/training_admission_telemetry_4gpu_e2e.ipynb
+++ b/docs/notebooks/training_admission_telemetry_4gpu_e2e.ipynb
@@ -19,12 +19,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pathlib import Path\n",
     "import json\n",
     "import os\n",
     "import subprocess\n",
     "import sys\n",
     "import tempfile\n",
+    "from pathlib import Path\n",
     "\n",
     "repo = Path.cwd().resolve()\n",
     "while repo.parent != repo and not (repo / \"pyproject.toml\").exists():\n",

--- a/docs/notebooks/training_admission_telemetry_4gpu_e2e.ipynb
+++ b/docs/notebooks/training_admission_telemetry_4gpu_e2e.ipynb
@@ -1,0 +1,183 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Training admission telemetry: 4-GPU DDP E2E\n",
+    "\n",
+    "This notebook runs the bounded end-to-end check used by the PR. It trains the same deterministic model twice (telemetry disabled and enabled), then requires exact checkpoint equality and one rank-local trace per microbatch. It does not download a model or dataset.\n",
+    "\n",
+    "Run the notebook from an AstrAI checkout with its normal dependencies installed. Four visible CUDA devices are required. Set `ASTRAI_E2E_GPUS` before this notebook if the physical devices are not `0,1,2,3`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "repo-setup",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import json\n",
+    "import os\n",
+    "import subprocess\n",
+    "import sys\n",
+    "import tempfile\n",
+    "\n",
+    "repo = Path.cwd().resolve()\n",
+    "while repo.parent != repo and not (repo / \"pyproject.toml\").exists():\n",
+    "    repo = repo.parent\n",
+    "assert (repo / \"scripts/eval/training_telemetry_ddp_e2e.py\").is_file(), (\n",
+    "    \"Run this notebook from the AstrAI repository.\"\n",
+    ")\n",
+    "print(f\"repository: {repo}\")\n",
+    "print(f\"python: {sys.executable}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gpu-select-info",
+   "metadata": {},
+   "source": [
+    "## Select GPUs and verify they are visible\n",
+    "\n",
+    "The test process receives only the devices listed below. It performs real DDP training and releases them when the command exits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "gpu-state",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gpu_ids = os.environ.get(\"ASTRAI_E2E_GPUS\", \"0,1,2,3\")\n",
+    "selected_gpus = [item.strip() for item in gpu_ids.split(\",\") if item.strip()]\n",
+    "assert len(selected_gpus) == 4, f\"expected four GPU IDs, got {selected_gpus}\"\n",
+    "gpu_state = subprocess.run(\n",
+    "    [\n",
+    "        \"nvidia-smi\",\n",
+    "        \"-i\",\n",
+    "        gpu_ids,\n",
+    "        \"--query-gpu=index,name,utilization.gpu,memory.used,memory.total\",\n",
+    "        \"--format=csv,noheader\",\n",
+    "    ],\n",
+    "    check=True,\n",
+    "    capture_output=True,\n",
+    "    text=True,\n",
+    ")\n",
+    "print(gpu_state.stdout)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "run-info",
+   "metadata": {},
+   "source": [
+    "## Run deterministic baseline and telemetry training\n",
+    "\n",
+    "The script creates an isolated temporary output directory, streams the complete log, and exits non-zero if checkpoints differ, any rank omits a trace, token accounting is wrong, or CUDA peak-memory evidence is absent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "run-e2e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_parent = Path(tempfile.mkdtemp(prefix=\"astrai-telemetry-notebook-\"))\n",
+    "output_dir = run_parent / \"run\"  # The E2E script requires a new path.\n",
+    "command = [\n",
+    "    sys.executable,\n",
+    "    str(repo / \"scripts/eval/training_telemetry_ddp_e2e.py\"),\n",
+    "    \"--world-size\",\n",
+    "    \"4\",\n",
+    "    \"--steps\",\n",
+    "    \"4\",\n",
+    "    \"--batch-per-device\",\n",
+    "    \"2\",\n",
+    "    \"--sequence-length\",\n",
+    "    \"32\",\n",
+    "    \"--output-dir\",\n",
+    "    str(output_dir),\n",
+    "]\n",
+    "environment = os.environ.copy()\n",
+    "environment[\"CUDA_VISIBLE_DEVICES\"] = gpu_ids\n",
+    "environment[\"PYTHONPATH\"] = str(repo)\n",
+    "environment[\"PYTHONUNBUFFERED\"] = \"1\"\n",
+    "print(\"running:\", \" \".join(command))\n",
+    "process = subprocess.Popen(\n",
+    "    command,\n",
+    "    cwd=repo,\n",
+    "    env=environment,\n",
+    "    stdout=subprocess.PIPE,\n",
+    "    stderr=subprocess.STDOUT,\n",
+    "    text=True,\n",
+    ")\n",
+    "assert process.stdout is not None\n",
+    "for line in process.stdout:\n",
+    "    print(line, end=\"\")\n",
+    "return_code = process.wait()\n",
+    "assert return_code == 0, f\"E2E failed with exit code {return_code}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "inspect-info",
+   "metadata": {},
+   "source": [
+    "## Inspect the independently written rank traces"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "inspect-traces",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trace_dir = output_dir / \"telemetry\" / \"traces\"\n",
+    "trace_counts = {}\n",
+    "peak_hbm_bytes = {}\n",
+    "for rank in range(4):\n",
+    "    path = trace_dir / f\"rank-{rank}.jsonl\"\n",
+    "    records = []\n",
+    "    for line in path.read_text(encoding=\"utf-8\").splitlines():\n",
+    "        prefix = \"training_telemetry \"\n",
+    "        if line.startswith(prefix):\n",
+    "            records.append(json.loads(line.removeprefix(prefix)))\n",
+    "    trace_counts[rank] = len(records)\n",
+    "    peak_hbm_bytes[rank] = max(record[\"peak_hbm_bytes\"] for record in records)\n",
+    "assert trace_counts == {0: 4, 1: 4, 2: 4, 3: 4}\n",
+    "assert all(value > 0 for value in peak_hbm_bytes.values())\n",
+    "{\"trace_counts\": trace_counts, \"peak_hbm_bytes\": peak_hbm_bytes}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "reference-run",
+   "metadata": {},
+   "source": [
+    "## Recorded reference run\n",
+    "\n",
+    "A clean run on 2026-09-04 used AstrAI commit `70772a442a5c692ac2c819ee6323f447f8422f7b`, PyTorch `2.11.0+cu128`, and four NVIDIA L20 GPUs. Each rank emitted four traces with a peak of `21,373,440` allocated bytes. Telemetry-off and telemetry-on checkpoints were exactly equal (`max_parameter_abs_diff = 0.0`) with matching SHA-256 `0a57a817a744babc3896b81abec802932e24c2b85d6bb50630a105709acc1d62`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/eval/training_telemetry_ddp_e2e.py
+++ b/scripts/eval/training_telemetry_ddp_e2e.py
@@ -24,7 +24,7 @@ from torch.utils.data import Dataset
 
 from astrai.config import AutoRegressiveLMConfig, TrainConfig
 from astrai.model.transformer import AutoRegressiveLM
-from astrai.parallel.setup import find_free_port
+from astrai.parallel.setup import find_free_port, get_rank
 from astrai.serialization import Checkpoint
 from astrai.trainer import Trainer
 
@@ -62,7 +62,10 @@ def _configure_trace_logging() -> None:
     trace_dir = os.environ.get(_TRACE_DIR_ENV)
     if not trace_dir:
         return
-    rank = int(os.environ.get("RANK", "0"))
+    # LocalStrategy passes rank directly to init_process_group instead of
+    # exporting RANK. Query the initialized process group so each spawned
+    # worker writes its own evidence file under both local and torchrun launch.
+    rank = get_rank()
     path = Path(trace_dir) / f"rank-{rank}.jsonl"
     path.parent.mkdir(parents=True, exist_ok=True)
     telemetry_logger = logging.getLogger("astrai.trainer.training_telemetry")

--- a/scripts/eval/training_telemetry_ddp_e2e.py
+++ b/scripts/eval/training_telemetry_ddp_e2e.py
@@ -1,0 +1,305 @@
+"""Run a bounded DDP parity check for rank-local training telemetry.
+
+Example:
+    CUDA_VISIBLE_DEVICES=0,1,2,3 PYTHONPATH=. python \
+        scripts/eval/training_telemetry_ddp_e2e.py \
+        --world-size 4 --output-dir /tmp/astrai-telemetry-e2e
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import torch
+from torch import nn
+from torch.optim import Optimizer
+from torch.optim.lr_scheduler import LambdaLR, LRScheduler
+from torch.utils.data import Dataset
+
+from astrai.config import AutoRegressiveLMConfig, TrainConfig
+from astrai.model.transformer import AutoRegressiveLM
+from astrai.parallel.setup import find_free_port
+from astrai.serialization import Checkpoint
+from astrai.trainer import Trainer
+
+_MODEL_SEED = 20260904
+_DATASET_SEED = 1907
+_TRACE_DIR_ENV = "ASTRAI_TELEMETRY_E2E_TRACE_DIR"
+
+
+class DeterministicTokenDataset(Dataset):
+    def __init__(self, length: int, sequence_length: int, vocab_size: int) -> None:
+        self.length = length
+        self.sequence_length = sequence_length
+        self.vocab_size = vocab_size
+
+    def __len__(self) -> int:
+        return self.length
+
+    def __getitem__(self, index: int) -> dict[str, torch.Tensor]:
+        generator = torch.Generator().manual_seed(_DATASET_SEED + index)
+        input_ids = torch.randint(
+            1,
+            self.vocab_size,
+            (self.sequence_length,),
+            generator=generator,
+        )
+        target_ids = torch.roll(input_ids, shifts=-1)
+        return {
+            "input_ids": input_ids,
+            "target_ids": target_ids,
+            "attention_mask": torch.ones(self.sequence_length, dtype=torch.bool),
+        }
+
+
+def _configure_trace_logging() -> None:
+    trace_dir = os.environ.get(_TRACE_DIR_ENV)
+    if not trace_dir:
+        return
+    rank = int(os.environ.get("RANK", "0"))
+    path = Path(trace_dir) / f"rank-{rank}.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    telemetry_logger = logging.getLogger("astrai.trainer.training_telemetry")
+    if any(
+        getattr(handler, "baseFilename", None) == str(path)
+        for handler in telemetry_logger.handlers
+    ):
+        return
+    handler = logging.FileHandler(path, encoding="utf-8")
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    telemetry_logger.addHandler(handler)
+    telemetry_logger.setLevel(logging.INFO)
+
+
+def build_model() -> nn.Module:
+    _configure_trace_logging()
+    torch.manual_seed(_MODEL_SEED)
+    config = AutoRegressiveLMConfig(
+        vocab_size=512,
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        intermediate_size=128,
+        max_position_embeddings=64,
+        num_hidden_layers=2,
+        rms_norm_eps=1e-5,
+    )
+    return AutoRegressiveLM(config)
+
+
+def build_optimizer(model: nn.Module) -> Optimizer:
+    return torch.optim.AdamW(model.parameters(), lr=1e-3, foreach=False)
+
+
+def build_scheduler(optimizer: Optimizer) -> LRScheduler:
+    return LambdaLR(optimizer, lr_lambda=lambda _: 1.0)
+
+
+def _run_training(
+    run_dir: Path,
+    *,
+    telemetry_enabled: bool,
+    world_size: int,
+    steps: int,
+    batch_per_device: int,
+    sequence_length: int,
+    device_type: str,
+) -> Path:
+    run_dir.mkdir(parents=True, exist_ok=False)
+    trace_dir = run_dir / "traces"
+    os.environ[_TRACE_DIR_ENV] = str(trace_dir)
+    dataset = DeterministicTokenDataset(
+        length=world_size * steps * batch_per_device,
+        sequence_length=sequence_length,
+        vocab_size=512,
+    )
+    config = TrainConfig(
+        model_fn=build_model,
+        strategy="seq",
+        dataset=dataset,
+        optimizer_fn=build_optimizer,
+        scheduler_fn=build_scheduler,
+        n_epoch=1,
+        batch_per_device=batch_per_device,
+        grad_accum_steps=1,
+        ckpt_dir=str(run_dir / "checkpoints"),
+        ckpt_interval=steps,
+        random_seed=_DATASET_SEED,
+        nprocs=world_size,
+        backend="nccl" if device_type == "cuda" else "gloo",
+        parallel_mode="ddp" if world_size > 1 else "none",
+        start_method="spawn",
+        device_type=device_type,
+        master_port=find_free_port(),
+        training_telemetry_enabled=telemetry_enabled,
+    )
+    Trainer(config).train()
+    return run_dir / "checkpoints" / f"epoch_0_step_{steps}"
+
+
+def _state_digest(state_dict: dict[str, torch.Tensor]) -> str:
+    digest = hashlib.sha256()
+    for name in sorted(state_dict):
+        tensor = state_dict[name].detach().cpu().contiguous()
+        digest.update(name.encode("utf-8"))
+        digest.update(str(tensor.dtype).encode("ascii"))
+        digest.update(str(tuple(tensor.shape)).encode("ascii"))
+        digest.update(tensor.numpy().tobytes())
+    return digest.hexdigest()
+
+
+def _compare_states(
+    baseline: dict[str, torch.Tensor], observed: dict[str, torch.Tensor]
+) -> tuple[bool, float]:
+    if baseline.keys() != observed.keys():
+        return False, float("inf")
+    exact = True
+    max_abs_diff = 0.0
+    for name, value in baseline.items():
+        left = value.detach().cpu()
+        right = observed[name].detach().cpu()
+        exact = exact and torch.equal(left, right)
+        max_abs_diff = max(
+            max_abs_diff,
+            float((left.float() - right.float()).abs().max().item()),
+        )
+    return exact, max_abs_diff
+
+
+def _load_traces(trace_dir: Path, world_size: int) -> dict[int, list[dict[str, Any]]]:
+    traces: dict[int, list[dict[str, Any]]] = {}
+    for rank in range(world_size):
+        path = trace_dir / f"rank-{rank}.jsonl"
+        records = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            prefix = "training_telemetry "
+            if line.startswith(prefix):
+                records.append(json.loads(line.removeprefix(prefix)))
+        traces[rank] = records
+    return traces
+
+
+def _validate_traces(
+    traces: dict[int, list[dict[str, Any]]],
+    *,
+    steps: int,
+    batch_per_device: int,
+    sequence_length: int,
+    require_hbm: bool,
+) -> None:
+    expected_tokens = batch_per_device * sequence_length
+    work_ids = set()
+    for rank, records in traces.items():
+        if len(records) != steps:
+            raise AssertionError(
+                f"rank {rank} emitted {len(records)} traces, expected {steps}"
+            )
+        for record in records:
+            work_item = record["work_item"]
+            work_ids.add(work_item["work_id"])
+            assert record["status"] == "ok"
+            if require_hbm:
+                assert record["peak_hbm_bytes"] > 0
+            else:
+                assert record["peak_hbm_bytes"] == 0
+            assert record["inflight_tokens_at_end"] == 0
+            assert work_item["rank"] == rank
+            assert work_item["cost"]["tokens"] == expected_tokens
+            assert work_item["estimation_error"] is None
+    if len(work_ids) != len(traces) * steps:
+        raise AssertionError("training work IDs are not globally unique")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--world-size", type=int, default=4)
+    parser.add_argument("--steps", type=int, default=4)
+    parser.add_argument("--batch-per-device", type=int, default=2)
+    parser.add_argument("--sequence-length", type=int, default=32)
+    parser.add_argument("--device-type", choices=("cuda", "cpu"), default="cuda")
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    if args.world_size < 1:
+        raise ValueError("world-size must be positive")
+    if args.device_type == "cuda" and torch.cuda.device_count() < args.world_size:
+        raise RuntimeError(
+            f"requested {args.world_size} GPUs, only {torch.cuda.device_count()} visible"
+        )
+    if args.output_dir.exists():
+        raise FileExistsError(f"output directory already exists: {args.output_dir}")
+    args.output_dir.mkdir(parents=True)
+
+    baseline_dir = args.output_dir / "baseline"
+    telemetry_dir = args.output_dir / "telemetry"
+    baseline_checkpoint = _run_training(
+        baseline_dir,
+        telemetry_enabled=False,
+        world_size=args.world_size,
+        steps=args.steps,
+        batch_per_device=args.batch_per_device,
+        sequence_length=args.sequence_length,
+        device_type=args.device_type,
+    )
+    telemetry_checkpoint = _run_training(
+        telemetry_dir,
+        telemetry_enabled=True,
+        world_size=args.world_size,
+        steps=args.steps,
+        batch_per_device=args.batch_per_device,
+        sequence_length=args.sequence_length,
+        device_type=args.device_type,
+    )
+
+    baseline_state = Checkpoint.load(
+        str(baseline_checkpoint), verify_checksums=True
+    ).state_dict
+    telemetry_state = Checkpoint.load(
+        str(telemetry_checkpoint), verify_checksums=True
+    ).state_dict
+    exact, max_abs_diff = _compare_states(baseline_state, telemetry_state)
+    traces = _load_traces(telemetry_dir / "traces", args.world_size)
+    _validate_traces(
+        traces,
+        steps=args.steps,
+        batch_per_device=args.batch_per_device,
+        sequence_length=args.sequence_length,
+        require_hbm=args.device_type == "cuda",
+    )
+    if not exact:
+        raise AssertionError(
+            f"telemetry changed trained parameters (max_abs_diff={max_abs_diff})"
+        )
+
+    peak_hbm_by_rank = {
+        str(rank): max(record["peak_hbm_bytes"] for record in records)
+        for rank, records in traces.items()
+    }
+    summary = {
+        "torch_version": torch.__version__,
+        "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES"),
+        "device_type": args.device_type,
+        "world_size": args.world_size,
+        "steps_per_rank": args.steps,
+        "batch_per_device": args.batch_per_device,
+        "sequence_length": args.sequence_length,
+        "traces_per_rank": {
+            str(rank): len(records) for rank, records in traces.items()
+        },
+        "peak_hbm_bytes_by_rank": peak_hbm_by_rank,
+        "parameters_exactly_equal": exact,
+        "max_parameter_abs_diff": max_abs_diff,
+        "baseline_parameter_sha256": _state_digest(baseline_state),
+        "telemetry_parameter_sha256": _state_digest(telemetry_state),
+    }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/trainer/test_training_telemetry.py
+++ b/tests/trainer/test_training_telemetry.py
@@ -1,0 +1,229 @@
+import json
+
+import pytest
+import torch
+
+from astrai.trainer.training_telemetry import (
+    NullTrainingTelemetry,
+    TokenCostModel,
+    TrainingTelemetry,
+    count_batch_tokens,
+)
+
+
+@pytest.mark.parametrize(
+    ("strategy", "batch", "expected"),
+    [
+        (
+            "sft",
+            {
+                "input_ids": torch.tensor([[11, 12, 0, 0], [21, 22, 23, 0]]),
+                "attention_mask": torch.tensor([[1, 1, 0, 0], [1, 1, 1, 0]]),
+                "loss_mask": torch.tensor([[0, 1, 0, 0], [0, 1, 1, 0]]),
+            },
+            (5, 0),
+        ),
+        (
+            "dpo",
+            {
+                "chosen": torch.tensor([[11, 12, 13, 0], [21, 22, 0, 0]]),
+                "rejected": torch.tensor([[11, 14, 0, 0], [21, 23, 24, 0]]),
+                "chosen_attention_mask": torch.tensor([[1, 1, 1, 0], [1, 1, 0, 0]]),
+                "rejected_attention_mask": torch.tensor([[1, 1, 0, 0], [1, 1, 1, 0]]),
+            },
+            (10, 0),
+        ),
+        (
+            "grpo",
+            {
+                "prompts": torch.tensor([[0, 11, 12], [21, 22, 23]]),
+                "prompt_mask": torch.tensor([[0, 1, 1], [1, 1, 1]]),
+                "responses": torch.tensor(
+                    [
+                        [[31, 32, 0], [33, 34, 35]],
+                        [[41, 0, 0], [42, 43, 0]],
+                    ]
+                ),
+                "masks": torch.tensor(
+                    [
+                        [[1, 1, 0], [1, 1, 1]],
+                        [[1, 0, 0], [1, 1, 0]],
+                    ]
+                ),
+            },
+            (10, 8),
+        ),
+    ],
+)
+def test_count_batch_tokens_matches_strategy_compute_shape(strategy, batch, expected):
+    snapshots = {key: value.clone() for key, value in batch.items()}
+
+    counts = count_batch_tokens(batch, strategy=strategy)
+
+    assert (counts.input_tokens, counts.output_tokens) == expected
+    assert counts.total_tokens == sum(expected)
+    assert all(torch.equal(batch[key], value) for key, value in snapshots.items())
+
+
+def test_token_cost_model_only_reports_configured_proxies():
+    model = TokenCostModel(
+        flops_per_token=6.0,
+        activation_bytes_per_token=12,
+        communication_bytes_per_token=4,
+        duration_ms_per_token=0.25,
+        confidence=0.7,
+    )
+
+    estimate = model.estimate(8)
+
+    assert estimate.tokens == 8
+    assert estimate.flops == 48.0
+    assert estimate.activation_bytes == 96
+    assert estimate.communication_bytes == 32
+    assert estimate.expected_duration_ms == 2.0
+    assert estimate.confidence == 0.7
+    assert TokenCostModel().estimate(8).flops is None
+    assert TokenCostModel().estimate(8).expected_duration_ms is None
+
+
+class _MemoryProbe:
+    def __init__(self, peak: int):
+        self.peak = peak
+        self.started_with = None
+
+    def start(self, device):
+        self.started_with = device
+
+    def stop(self) -> int:
+        return self.peak
+
+
+def test_observe_batch_tracks_rank_local_pressure_and_emits_structured_trace():
+    traces = []
+    times = iter((10.0, 10.25))
+    probe = _MemoryProbe(peak=123456)
+    telemetry = TrainingTelemetry(
+        cost_model=TokenCostModel(flops_per_token=2.0),
+        sink=traces.append,
+        clock=lambda: next(times),
+        memory_probe=probe,
+    )
+    batch = {
+        "input_ids": torch.tensor([[1, 2, 3, 0]]),
+        "attention_mask": torch.tensor([[1, 1, 1, 0]]),
+    }
+
+    with telemetry.observe_batch(
+        batch,
+        strategy="seq",
+        rank=2,
+        world_size=4,
+        epoch=3,
+        optimizer_step=7,
+        policy_version=11,
+        device="cuda:2",
+    ) as work:
+        assert work.work_id == "train-r2-e3-s7-m0"
+        assert work.phase == "train"
+        assert work.rank == 2
+        assert work.world_size == 4
+        assert work.policy_version == 11
+        assert work.cost.tokens == 3
+        assert telemetry.inflight_tokens == 3
+
+    assert telemetry.inflight_tokens == 0
+    assert probe.started_with == "cuda:2"
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace.work_item == work
+    assert trace.status == "ok"
+    assert trace.host_duration_ms == 250.0
+    assert trace.peak_hbm_bytes == 123456
+    assert trace.inflight_tokens_at_start == 3
+    assert trace.inflight_tokens_at_end == 0
+    assert trace.error_type is None
+    payload = json.loads(trace.to_json())
+    assert payload["event"] == "training_work_item_completed"
+    assert payload["work_item"]["work_id"] == work.work_id
+
+
+def test_observe_batch_releases_pressure_without_masking_training_error(caplog):
+    traces = []
+
+    def broken_sink(trace):
+        traces.append(trace)
+        raise RuntimeError("sink failed")
+
+    telemetry = TrainingTelemetry(sink=broken_sink)
+    batch = {"input_ids": torch.ones((2, 4), dtype=torch.long)}
+
+    with (
+        pytest.raises(ValueError, match="training failed"),
+        telemetry.observe_batch(
+            batch,
+            strategy="seq",
+            rank=0,
+            world_size=1,
+            epoch=0,
+            optimizer_step=0,
+        ),
+    ):
+        raise ValueError("training failed")
+
+    assert telemetry.inflight_tokens == 0
+    assert traces[0].status == "error"
+    assert traces[0].error_type == "ValueError"
+    assert "training telemetry sink failed" in caplog.text
+
+
+def test_disabled_telemetry_does_not_inspect_batch_or_emit_trace():
+    class _ExplodingBatch:
+        def get(self, key, default=None):
+            raise AssertionError("disabled telemetry inspected the batch")
+
+    telemetry = NullTrainingTelemetry()
+
+    with telemetry.observe_batch(
+        _ExplodingBatch(),
+        strategy="seq",
+        rank=0,
+        world_size=1,
+        epoch=0,
+        optimizer_step=0,
+    ) as work:
+        assert work is None
+
+    assert telemetry.inflight_tokens == 0
+
+
+def test_trainer_emits_one_trace_per_completed_batch(
+    base_test_env, train_config_factory, device, caplog
+):
+    from tests.helpers import RandomTokenDataset
+
+    train_config = train_config_factory(
+        model_fn=lambda: base_test_env["model"],
+        dataset=RandomTokenDataset(length=4, max_length=8),
+        test_dir=base_test_env["test_dir"],
+        device=device,
+        batch_per_device=2,
+        training_telemetry_enabled=True,
+    )
+
+    with caplog.at_level("INFO", logger="astrai.trainer.training_telemetry"):
+        from astrai.trainer import Trainer
+
+        Trainer(train_config).train()
+
+    payloads = [
+        json.loads(record.message.removeprefix("training_telemetry "))
+        for record in caplog.records
+        if record.message.startswith("training_telemetry ")
+    ]
+    assert len(payloads) == 2
+    assert [payload["work_item"]["cost"]["tokens"] for payload in payloads] == [
+        16,
+        16,
+    ]
+    assert all(payload["work_item"]["rank"] == 0 for payload in payloads)
+    assert all(payload["inflight_tokens_at_end"] == 0 for payload in payloads)


### PR DESCRIPTION
## Description

This PR adds the rank-local observability layer needed before training admission or placement policies can make informed decisions. It deliberately does **not** move microbatches, synchronize ranks, change MoE routing, or otherwise alter training semantics.

The new telemetry path:

- models each completed microbatch as a structured `WorkItem` / `TrainingTrace`;
- counts tokens according to the actual strategy shape (sequence/SFT, chosen + rejected DPO, and grouped prompt + response GRPO);
- tracks rank-local in-flight token pressure, host duration, and CUDA peak allocated memory;
- supports explicitly calibrated FLOP, activation, communication, and duration proxies without inventing values when coefficients are unknown;
- fails open if token estimation, memory probing, or an optional sink fails;
- remains completely disabled by default and avoids inspecting batches on the disabled path;
- exposes opt-in `TrainConfig` fields and integrates one observation context around each real trainer microbatch.

A bounded DDP parity script and a runnable reviewer notebook are included. The E2E trains a deterministic model with telemetry off and on, requires byte-for-byte-equivalent parameters, and validates independently written traces from every rank.

Reproduction notebook: `docs/notebooks/training_admission_telemetry_4gpu_e2e.ipynb`

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## How Has This Been Tested?

### Unit and repository tests

```text
PYTHONPATH=. uv run --python 3.12 --extra dev --with httpx2 pytest -q
658 passed, 181 skipped, 1 warning in 12.49s

ruff check astrai/trainer/training_telemetry.py \
  scripts/eval/training_telemetry_ddp_e2e.py \
  tests/trainer/test_training_telemetry.py
All checks passed!

ruff format --check astrai/trainer/training_telemetry.py \
  scripts/eval/training_telemetry_ddp_e2e.py \
  tests/trainer/test_training_telemetry.py
3 files already formatted
```

The single warning is an existing Starlette/AnyIO deprecation warning during test collection. `httpx2` was supplied only to satisfy the current Starlette test-client environment; this PR does not change project dependencies.

### Real 4-GPU DDP E2E

Hardware: 4 × NVIDIA L20 46 GiB  
Software: PyTorch `2.11.0+cu128`

```bash
CUDA_VISIBLE_DEVICES=0,1,3,4 PYTHONPATH=. python \
  scripts/eval/training_telemetry_ddp_e2e.py \
  --world-size 4 \
  --steps 4 \
  --batch-per-device 2 \
  --sequence-length 32 \
  --output-dir /tmp/astrai-training-telemetry-4gpu
```

Final validated summary from the clean run:

```text
world_size: 4
steps_per_rank: 4
traces_per_rank: {0: 4, 1: 4, 2: 4, 3: 4}
peak_hbm_bytes_by_rank: {0: 21373440, 1: 21373440, 2: 21373440, 3: 21373440}
parameters_exactly_equal: true
max_parameter_abs_diff: 0.0
baseline_parameter_sha256: 0a57a817a744babc3896b81abec802932e24c2b85d6bb50630a105709acc1d62
telemetry_parameter_sha256: 0a57a817a744babc3896b81abec802932e24c2b85d6bb50630a105709acc1d62
exit_code: 0
```

The notebook runs the same command, streams the complete log, checks the exit code, reads all four rank-specific JSONL trace files, and asserts both trace counts and non-zero CUDA peak-memory evidence.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] Code is self-documenting (no unnecessary comments)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] This change has no unpublished downstream dependency
