### PR TITLE
feat: shard rollout-bound route trace payloads

### DIFF
--- a/astrai/moe/__init__.py
+++ b/astrai/moe/__init__.py
@@ -1,0 +1,49 @@
+"""Semantic contracts and diagnostics for mixture-of-experts routing."""
+
+from astrai.moe.route_metrics import (
+    RouteAlignmentMetricsV0,
+    compare_route_traces,
+    compute_topk_margin,
+)
+from astrai.moe.route_trace import (
+    ROUTE_TRACE_SCHEMA_VERSION,
+    PaddingLayout,
+    RouteIdentityV0,
+    RouterSchemaV0,
+    RouteTokenLayoutV0,
+    RouteTraceCodecV0,
+    RouteTraceLevel,
+    RouteTraceV0,
+    RouteTraceValidationError,
+    SelectedWeightSemantics,
+    TokenSpanKind,
+    canonical_json_digest,
+    pack_route_ids,
+    recommended_route_id_dtype,
+    require_compatible_route_trace,
+    require_semantically_aligned_traces,
+    validate_route_trace,
+)
+
+__all__ = [
+    "ROUTE_TRACE_SCHEMA_VERSION",
+    "PaddingLayout",
+    "RouteAlignmentMetricsV0",
+    "RouteIdentityV0",
+    "RouteTokenLayoutV0",
+    "RouteTraceCodecV0",
+    "RouteTraceLevel",
+    "RouteTraceV0",
+    "RouteTraceValidationError",
+    "RouterSchemaV0",
+    "SelectedWeightSemantics",
+    "TokenSpanKind",
+    "canonical_json_digest",
+    "compare_route_traces",
+    "compute_topk_margin",
+    "pack_route_ids",
+    "recommended_route_id_dtype",
+    "require_compatible_route_trace",
+    "require_semantically_aligned_traces",
+    "validate_route_trace",
+]

--- a/astrai/moe/route_metrics.py
+++ b/astrai/moe/route_metrics.py
@@ -1,0 +1,166 @@
+"""Pure alignment diagnostics for compatible versioned MoE route traces."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import torch
+
+from astrai.moe.route_trace import (
+    RouteTraceV0,
+    RouteTraceValidationError,
+    require_semantically_aligned_traces,
+)
+
+
+@dataclass(frozen=True)
+class RouteAlignmentMetricsV0:
+    """Aggregated behavior/current route alignment without changing policy."""
+
+    behavior_policy_version: int
+    current_policy_version: int
+    valid_token_count: int
+    compared_token_layer_count: int
+    ordered_topk_match_fraction: float
+    unordered_topk_overlap_fraction: float
+    route_set_flip_fraction: float
+    selected_weight_l1_mean: float | None
+    behavior_margin_mean: float | None
+    behavior_fragile_fraction: float | None
+    fragile_margin_threshold: float | None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-compatible scalar diagnostics."""
+        return asdict(self)
+
+
+def compute_topk_margin(router_scores: torch.Tensor, top_k: int) -> torch.Tensor:
+    """Compute top-k versus top-(k+1) margin in FP32.
+
+    The explicit FP32 conversion gives BF16/FP16 callers one documented
+    diagnostic reference. It does not choose or override expert IDs.
+    """
+    if not isinstance(router_scores, torch.Tensor):
+        raise RouteTraceValidationError("router_scores must be a torch.Tensor")
+    if not router_scores.is_floating_point() or router_scores.ndim < 1:
+        raise RouteTraceValidationError("router_scores must be a floating tensor")
+    if isinstance(top_k, bool) or not isinstance(top_k, int) or top_k < 1:
+        raise RouteTraceValidationError("top_k must be a positive integer")
+    if top_k >= router_scores.shape[-1]:
+        raise RouteTraceValidationError(
+            "top-k margin requires at least one unselected expert"
+        )
+    if not bool(torch.isfinite(router_scores).all().item()):
+        raise RouteTraceValidationError("router_scores must be finite")
+    values = torch.topk(router_scores.float(), top_k + 1, dim=-1, sorted=True).values
+    return values[..., top_k - 1] - values[..., top_k]
+
+
+def _valid_token_layer_mask(trace: RouteTraceV0) -> torch.Tensor:
+    if trace.valid_mask is None:
+        token_mask = torch.ones(
+            trace.token_layout.token_count,
+            dtype=torch.bool,
+            device=trace.topk_ids.device,
+        )
+    else:
+        token_mask = trace.valid_mask
+    return token_mask[:, None].expand(-1, trace.router_schema.num_moe_layers)
+
+
+def _selected_weight_l1(
+    behavior: RouteTraceV0, current: RouteTraceV0
+) -> torch.Tensor | None:
+    if behavior.selected_weights is None or current.selected_weights is None:
+        return None
+    behavior_ids = behavior.topk_ids.to(dtype=torch.int64)
+    current_ids = current.topk_ids.to(dtype=torch.int64)
+    behavior_weights = behavior.selected_weights.float()
+    current_weights = current.selected_weights.float()
+    same_expert = behavior_ids.unsqueeze(-1) == current_ids.unsqueeze(-2)
+    current_for_behavior = (
+        same_expert.to(dtype=current_weights.dtype) * current_weights.unsqueeze(-2)
+    ).sum(dim=-1)
+    behavior_mass_delta = (behavior_weights - current_for_behavior).abs().sum(dim=-1)
+    unmatched_current = ~same_expert.any(dim=-2)
+    unmatched_current_mass = (current_weights * unmatched_current).sum(dim=-1)
+    return behavior_mass_delta + unmatched_current_mass
+
+
+def compare_route_traces(
+    behavior: RouteTraceV0,
+    current: RouteTraceV0,
+    *,
+    fragile_margin_threshold: float | None = None,
+) -> RouteAlignmentMetricsV0:
+    """Compare exact ordered IDs, expert sets, selected mass, and margin.
+
+    Identity versions may differ because the purpose is to measure drift, but
+    router semantics, token layout, validity mask, and device must match
+    exactly. Missing optional tensors produce explicit ``None`` metrics rather
+    than fabricated zero drift.
+    """
+    require_semantically_aligned_traces(behavior, current)
+    if fragile_margin_threshold is not None:
+        if (
+            isinstance(fragile_margin_threshold, bool)
+            or not isinstance(fragile_margin_threshold, (int, float))
+            or not math.isfinite(fragile_margin_threshold)
+            or fragile_margin_threshold < 0
+        ):
+            raise RouteTraceValidationError(
+                "fragile_margin_threshold must be a finite non-negative number"
+            )
+        fragile_margin_threshold = float(fragile_margin_threshold)
+
+    valid_positions = _valid_token_layer_mask(behavior)
+    compared_positions = int(valid_positions.sum().item())
+    if compared_positions == 0:
+        raise RouteTraceValidationError(
+            "route metrics require at least one valid token-layer"
+        )
+
+    behavior_ids = behavior.topk_ids.to(dtype=torch.int64)
+    current_ids = current.topk_ids.to(dtype=torch.int64)
+    ordered_match = (behavior_ids == current_ids).all(dim=-1)
+    same_expert = behavior_ids.unsqueeze(-1) == current_ids.unsqueeze(-2)
+    overlap = same_expert.any(dim=-1).float().mean(dim=-1)
+    ordered_fraction = float(ordered_match[valid_positions].float().mean().item())
+    overlap_fraction = float(overlap[valid_positions].mean().item())
+
+    weight_l1 = _selected_weight_l1(behavior, current)
+    weight_l1_mean = (
+        float(weight_l1[valid_positions].mean().item())
+        if weight_l1 is not None
+        else None
+    )
+
+    margin_mean = None
+    fragile_fraction = None
+    if behavior.topk_margin is not None:
+        valid_margins = behavior.topk_margin.float()[valid_positions]
+        margin_mean = float(valid_margins.mean().item())
+        if fragile_margin_threshold is not None:
+            fragile_fraction = float(
+                (valid_margins < fragile_margin_threshold).float().mean().item()
+            )
+    elif fragile_margin_threshold is not None:
+        raise RouteTraceValidationError(
+            "fragile margin diagnostics require behavior topk_margin"
+        )
+
+    return RouteAlignmentMetricsV0(
+        behavior_policy_version=behavior.identity.policy_version,
+        current_policy_version=current.identity.policy_version,
+        valid_token_count=behavior.valid_token_count,
+        compared_token_layer_count=compared_positions,
+        ordered_topk_match_fraction=ordered_fraction,
+        unordered_topk_overlap_fraction=overlap_fraction,
+        route_set_flip_fraction=1.0 - overlap_fraction,
+        selected_weight_l1_mean=weight_l1_mean,
+        behavior_margin_mean=margin_mean,
+        behavior_fragile_fraction=fragile_fraction,
+        fragile_margin_threshold=fragile_margin_threshold,
+    )

--- a/astrai/moe/route_trace.py
+++ b/astrai/moe/route_trace.py
@@ -1,0 +1,944 @@
+"""Versioned, compact, and fail-closed MoE route trace artifacts.
+
+This module defines the data contract only. It does not capture routes from a
+model, alter expert dispatch, or apply replay during training. The separation
+keeps the default model path unchanged while rollout and training backends gain
+a common artifact they can validate before later integrations consume it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+import safetensors.torch as safetensors
+import torch
+from torch import Tensor
+
+ROUTE_TRACE_SCHEMA_VERSION = 0
+
+_CODEC_NAME = "astrai-route-trace-safetensors-raw-v0"
+_MANIFEST_TENSOR = "__route_trace_manifest_v0__"
+_MAX_MANIFEST_BYTES = 1024 * 1024
+_DEFAULT_MAX_SERIALIZED_BYTES = 1024 * 1024 * 1024
+_SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
+
+_FLOAT_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+_DTYPE_BY_NAME = {
+    "bool": torch.bool,
+    "bfloat16": torch.bfloat16,
+    "float16": torch.float16,
+    "float32": torch.float32,
+    "uint8": torch.uint8,
+    "uint16": torch.uint16,
+    "uint32": torch.uint32,
+}
+_TENSOR_NAMES = ("topk_ids", "selected_weights", "topk_margin", "valid_mask")
+
+
+class RouteTraceValidationError(ValueError):
+    """A route trace cannot be interpreted under the declared contract."""
+
+
+class RouteTraceLevel(str, Enum):
+    """Payload tiers supported by the version-zero contract."""
+
+    IDS = "ids"
+    IDS_WEIGHTS_MARGIN = "ids_weights_margin"
+
+
+class SelectedWeightSemantics(str, Enum):
+    """How selected expert weights relate to the full router distribution."""
+
+    FULL_SOFTMAX_SELECTED = "full-softmax-selected"
+    SELECTED_RENORMALIZED = "selected-renormalized"
+
+
+class PaddingLayout(str, Enum):
+    """Validity-mask ordering for the flattened token span."""
+
+    NONE = "none"
+    LEFT = "left"
+    RIGHT = "right"
+    EXPLICIT_MASK = "explicit-mask"
+
+
+class TokenSpanKind(str, Enum):
+    """Relationship of the captured span to prompt and response tokens."""
+
+    FULL_SEQUENCE = "full-sequence"
+    PROMPT = "prompt"
+    RESPONSE = "response"
+    CONTIGUOUS = "contiguous-span"
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    try:
+        encoded = json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError) as exc:
+        raise RouteTraceValidationError(
+            "value is not canonical-JSON serializable"
+        ) from exc
+    return encoded.encode("utf-8")
+
+
+def canonical_json_digest(value: Any) -> str:
+    """Return a content-addressed SHA-256 digest for JSON-compatible metadata."""
+    return hashlib.sha256(_canonical_json_bytes(value)).hexdigest()
+
+
+def _require_int(
+    name: str, value: Any, *, minimum: int, maximum: int | None = None
+) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise RouteTraceValidationError(f"{name} must be an integer >= {minimum}")
+    if maximum is not None and value > maximum:
+        raise RouteTraceValidationError(f"{name} must be <= {maximum}")
+    return value
+
+
+def _require_text(name: str, value: Any) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value or len(value) > 1024:
+        raise RouteTraceValidationError(f"{name} must be a non-empty bounded string")
+    return value
+
+
+def _require_digest(name: str, value: Any) -> str:
+    if not isinstance(value, str) or _SHA256_PATTERN.fullmatch(value) is None:
+        raise RouteTraceValidationError(f"{name} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _require_exact_keys(
+    value: Any, expected: set[str], label: str
+) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise RouteTraceValidationError(f"{label} must be a mapping")
+    keys = set(value)
+    if keys != expected:
+        missing = sorted(expected - keys)
+        unknown = sorted(keys - expected)
+        raise RouteTraceValidationError(
+            f"{label} keys do not match version-zero schema; missing={missing}, unknown={unknown}"
+        )
+    return value
+
+
+def _parse_enum(enum_type: type[Enum], name: str, value: Any) -> Enum:
+    try:
+        return enum_type(value)
+    except (TypeError, ValueError) as exc:
+        raise RouteTraceValidationError(f"unsupported {name}: {value!r}") from exc
+
+
+@dataclass(frozen=True)
+class RouterSchemaV0:
+    """Semantic identity required to interpret route IDs and selected weights."""
+
+    num_moe_layers: int
+    num_experts: int
+    top_k: int
+    expert_parallel_world_size: int
+    score_function: str
+    score_dtype: str
+    expert_id_ordering: str
+    selected_weight_semantics: SelectedWeightSemantics
+    token_ordering: str
+    padding_layout: PaddingLayout
+    backend: str
+    kernel_semantics_version: str
+    parallel_layout_hash: str
+
+    def __post_init__(self) -> None:
+        _require_int("num_moe_layers", self.num_moe_layers, minimum=1)
+        _require_int("num_experts", self.num_experts, minimum=1, maximum=2**32)
+        _require_int("top_k", self.top_k, minimum=1, maximum=self.num_experts)
+        _require_int(
+            "expert_parallel_world_size", self.expert_parallel_world_size, minimum=1
+        )
+        for name in (
+            "score_function",
+            "score_dtype",
+            "expert_id_ordering",
+            "token_ordering",
+            "backend",
+            "kernel_semantics_version",
+        ):
+            _require_text(name, getattr(self, name))
+        if not isinstance(self.selected_weight_semantics, SelectedWeightSemantics):
+            raise RouteTraceValidationError(
+                "selected_weight_semantics must use the declared enum"
+            )
+        if not isinstance(self.padding_layout, PaddingLayout):
+            raise RouteTraceValidationError("padding_layout must use the declared enum")
+        _require_digest("parallel_layout_hash", self.parallel_layout_hash)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical JSON-compatible schema representation."""
+        return {
+            "backend": self.backend,
+            "expert_id_ordering": self.expert_id_ordering,
+            "expert_parallel_world_size": self.expert_parallel_world_size,
+            "kernel_semantics_version": self.kernel_semantics_version,
+            "num_experts": self.num_experts,
+            "num_moe_layers": self.num_moe_layers,
+            "padding_layout": self.padding_layout.value,
+            "parallel_layout_hash": self.parallel_layout_hash,
+            "score_dtype": self.score_dtype,
+            "score_function": self.score_function,
+            "selected_weight_semantics": self.selected_weight_semantics.value,
+            "token_ordering": self.token_ordering,
+            "top_k": self.top_k,
+        }
+
+    @property
+    def fingerprint(self) -> str:
+        """Return the content address used as ``router_schema_hash``."""
+        return canonical_json_digest(
+            {"route_trace_schema_version": ROUTE_TRACE_SCHEMA_VERSION, **self.to_dict()}
+        )
+
+    @classmethod
+    def from_dict(cls, value: Any) -> RouterSchemaV0:
+        """Parse a strict version-zero router schema."""
+        fields = {
+            "backend",
+            "expert_id_ordering",
+            "expert_parallel_world_size",
+            "kernel_semantics_version",
+            "num_experts",
+            "num_moe_layers",
+            "padding_layout",
+            "parallel_layout_hash",
+            "score_dtype",
+            "score_function",
+            "selected_weight_semantics",
+            "token_ordering",
+            "top_k",
+        }
+        value = _require_exact_keys(value, fields, "router_schema")
+        return cls(
+            num_moe_layers=value["num_moe_layers"],
+            num_experts=value["num_experts"],
+            top_k=value["top_k"],
+            expert_parallel_world_size=value["expert_parallel_world_size"],
+            score_function=value["score_function"],
+            score_dtype=value["score_dtype"],
+            expert_id_ordering=value["expert_id_ordering"],
+            selected_weight_semantics=_parse_enum(
+                SelectedWeightSemantics,
+                "selected_weight_semantics",
+                value["selected_weight_semantics"],
+            ),
+            token_ordering=value["token_ordering"],
+            padding_layout=_parse_enum(
+                PaddingLayout, "padding_layout", value["padding_layout"]
+            ),
+            backend=value["backend"],
+            kernel_semantics_version=value["kernel_semantics_version"],
+            parallel_layout_hash=value["parallel_layout_hash"],
+        )
+
+
+@dataclass(frozen=True)
+class RouteIdentityV0:
+    """Versions and revisions that attribute a trace to one behavior policy."""
+
+    policy_version: int
+    model_revision: str
+    router_state_version: int
+    checkpoint_revision: str
+    router_schema_hash: str
+    load_controller_version: int = 0
+
+    def __post_init__(self) -> None:
+        _require_int("policy_version", self.policy_version, minimum=0)
+        _require_int("router_state_version", self.router_state_version, minimum=0)
+        _require_int("load_controller_version", self.load_controller_version, minimum=0)
+        _require_text("model_revision", self.model_revision)
+        _require_text("checkpoint_revision", self.checkpoint_revision)
+        _require_digest("router_schema_hash", self.router_schema_hash)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical JSON-compatible identity representation."""
+        return {
+            "checkpoint_revision": self.checkpoint_revision,
+            "load_controller_version": self.load_controller_version,
+            "model_revision": self.model_revision,
+            "policy_version": self.policy_version,
+            "router_schema_hash": self.router_schema_hash,
+            "router_state_version": self.router_state_version,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> RouteIdentityV0:
+        """Parse a strict version-zero route identity."""
+        fields = {
+            "checkpoint_revision",
+            "load_controller_version",
+            "model_revision",
+            "policy_version",
+            "router_schema_hash",
+            "router_state_version",
+        }
+        value = _require_exact_keys(value, fields, "identity")
+        return cls(**{name: value[name] for name in fields})
+
+
+@dataclass(frozen=True)
+class RouteTokenLayoutV0:
+    """One sample's flattened contiguous token span and prompt boundary."""
+
+    sample_id: str
+    sequence_token_count: int
+    prompt_token_count: int
+    token_offset: int
+    token_count: int
+    span_kind: TokenSpanKind
+
+    def __post_init__(self) -> None:
+        _require_text("sample_id", self.sample_id)
+        _require_int("sequence_token_count", self.sequence_token_count, minimum=0)
+        _require_int(
+            "prompt_token_count",
+            self.prompt_token_count,
+            minimum=0,
+            maximum=self.sequence_token_count,
+        )
+        _require_int("token_offset", self.token_offset, minimum=0)
+        _require_int("token_count", self.token_count, minimum=0)
+        if self.token_offset + self.token_count > self.sequence_token_count:
+            raise RouteTraceValidationError(
+                "captured token span exceeds the sequence boundary"
+            )
+        if not isinstance(self.span_kind, TokenSpanKind):
+            raise RouteTraceValidationError("span_kind must use the declared enum")
+        if self.span_kind is TokenSpanKind.FULL_SEQUENCE and (
+            self.token_offset != 0 or self.token_count != self.sequence_token_count
+        ):
+            raise RouteTraceValidationError(
+                "full-sequence span must cover the complete sequence"
+            )
+        if self.span_kind is TokenSpanKind.PROMPT and (
+            self.token_offset != 0 or self.token_count != self.prompt_token_count
+        ):
+            raise RouteTraceValidationError(
+                "prompt span must exactly cover the prompt boundary"
+            )
+        if (
+            self.span_kind is TokenSpanKind.RESPONSE
+            and self.token_offset < self.prompt_token_count
+        ):
+            raise RouteTraceValidationError(
+                "response span cannot begin inside the prompt"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical JSON-compatible token layout."""
+        return {
+            "prompt_token_count": self.prompt_token_count,
+            "sample_id": self.sample_id,
+            "sequence_token_count": self.sequence_token_count,
+            "span_kind": self.span_kind.value,
+            "token_count": self.token_count,
+            "token_offset": self.token_offset,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> RouteTokenLayoutV0:
+        """Parse a strict version-zero token layout."""
+        fields = {
+            "prompt_token_count",
+            "sample_id",
+            "sequence_token_count",
+            "span_kind",
+            "token_count",
+            "token_offset",
+        }
+        value = _require_exact_keys(value, fields, "token_layout")
+        return cls(
+            sample_id=value["sample_id"],
+            sequence_token_count=value["sequence_token_count"],
+            prompt_token_count=value["prompt_token_count"],
+            token_offset=value["token_offset"],
+            token_count=value["token_count"],
+            span_kind=_parse_enum(TokenSpanKind, "span_kind", value["span_kind"]),
+        )
+
+
+def recommended_route_id_dtype(num_experts: int) -> torch.dtype:
+    """Return the narrowest unsigned dtype that represents every expert ID."""
+    _require_int("num_experts", num_experts, minimum=1, maximum=2**32)
+    if num_experts <= 2**8:
+        return torch.uint8
+    if num_experts <= 2**16:
+        return torch.uint16
+    return torch.uint32
+
+
+def pack_route_ids(topk_ids: Tensor, num_experts: int) -> Tensor:
+    """Validate expert IDs and copy them into the canonical compact dtype."""
+    if not isinstance(topk_ids, Tensor):
+        raise RouteTraceValidationError("topk_ids must be a torch.Tensor")
+    integral_dtypes = (
+        torch.int8,
+        torch.int16,
+        torch.int32,
+        torch.int64,
+        torch.uint8,
+        torch.uint16,
+        torch.uint32,
+    )
+    if topk_ids.dtype not in integral_dtypes:
+        raise RouteTraceValidationError("topk_ids must use an integer dtype")
+    _require_int("num_experts", num_experts, minimum=1, maximum=2**32)
+    ids64 = topk_ids.detach().to(dtype=torch.int64)
+    if ids64.numel() and (ids64.min().item() < 0 or ids64.max().item() >= num_experts):
+        raise RouteTraceValidationError(
+            "topk_ids contains an expert outside the declared range"
+        )
+    return (
+        topk_ids.detach()
+        .to(dtype=recommended_route_id_dtype(num_experts), copy=True)
+        .contiguous()
+    )
+
+
+@dataclass(frozen=True, eq=False)
+class RouteTraceV0:
+    """A compact route artifact for one contiguous token span.
+
+    Tensors use token-major shapes ``[T, L, K]`` for IDs and weights,
+    ``[T, L]`` for margins, and ``[T]`` for the optional validity mask. The
+    constructor validates all identity, shape, dtype, range, and padding
+    invariants. Consumers must validate again at their trust boundary because
+    tensors remain mutable Python objects even though this dataclass is frozen.
+    """
+
+    identity: RouteIdentityV0
+    router_schema: RouterSchemaV0
+    token_layout: RouteTokenLayoutV0
+    level: RouteTraceLevel
+    topk_ids: Tensor
+    selected_weights: Tensor | None = None
+    topk_margin: Tensor | None = None
+    valid_mask: Tensor | None = None
+
+    def __post_init__(self) -> None:
+        validate_route_trace(self)
+
+    @property
+    def valid_token_count(self) -> int:
+        """Return the number of captured tokens marked valid."""
+        if self.valid_mask is None:
+            return self.token_layout.token_count
+        return int(self.valid_mask.sum().item())
+
+    @property
+    def payload_nbytes(self) -> int:
+        """Return exact tensor payload bytes, excluding the manifest/container."""
+        tensors = (
+            self.topk_ids,
+            self.selected_weights,
+            self.topk_margin,
+            self.valid_mask,
+        )
+        return sum(
+            tensor.numel() * tensor.element_size()
+            for tensor in tensors
+            if tensor is not None
+        )
+
+    @property
+    def artifact_digest(self) -> str:
+        """Return the content address of the canonical serialized artifact."""
+        return hashlib.sha256(RouteTraceCodecV0.dumps(self)).hexdigest()
+
+
+def _effective_valid_mask(trace: RouteTraceV0) -> Tensor:
+    if trace.valid_mask is not None:
+        return trace.valid_mask
+    return torch.ones(
+        trace.token_layout.token_count, dtype=torch.bool, device=trace.topk_ids.device
+    )
+
+
+def _validate_padding_mask(trace: RouteTraceV0, mask: Tensor) -> None:
+    layout = trace.router_schema.padding_layout
+    if layout is PaddingLayout.EXPLICIT_MASK and trace.valid_mask is None:
+        raise RouteTraceValidationError("explicit-mask layout requires valid_mask")
+    if layout is PaddingLayout.NONE and mask.numel() and not bool(mask.all().item()):
+        raise RouteTraceValidationError(
+            "padding_layout=none cannot contain invalid tokens"
+        )
+    if mask.numel() < 2:
+        return
+    if layout is PaddingLayout.LEFT and bool((mask[:-1] & ~mask[1:]).any().item()):
+        raise RouteTraceValidationError(
+            "left padding mask must be false tokens followed by true tokens"
+        )
+    if layout is PaddingLayout.RIGHT and bool((~mask[:-1] & mask[1:]).any().item()):
+        raise RouteTraceValidationError(
+            "right padding mask must be true tokens followed by false tokens"
+        )
+
+
+def _validate_float_tensor(
+    name: str, tensor: Tensor, expected_shape: tuple[int, ...], device: torch.device
+) -> None:
+    if not isinstance(tensor, Tensor):
+        raise RouteTraceValidationError(f"{name} must be a torch.Tensor")
+    if tensor.layout is not torch.strided or tensor.device.type == "meta":
+        raise RouteTraceValidationError(f"{name} must be a materialized strided tensor")
+    if tensor.dtype not in _FLOAT_DTYPES:
+        raise RouteTraceValidationError(
+            f"{name} must use float16, bfloat16, or float32"
+        )
+    if tuple(tensor.shape) != expected_shape:
+        raise RouteTraceValidationError(
+            f"{name} shape must be {expected_shape}, got {tuple(tensor.shape)}"
+        )
+    if tensor.device != device:
+        raise RouteTraceValidationError(
+            f"{name} must be on the same device as topk_ids"
+        )
+    if tensor.requires_grad:
+        raise RouteTraceValidationError(f"{name} must be detached from autograd")
+    negative_zero = (tensor == 0) & torch.signbit(tensor)
+    if negative_zero.numel() and bool(negative_zero.any().item()):
+        raise RouteTraceValidationError(
+            f"{name} must use canonical positive zero values"
+        )
+
+
+def validate_route_trace(trace: RouteTraceV0) -> None:
+    """Validate one trace's complete internal contract, failing closed."""
+    if not isinstance(trace.identity, RouteIdentityV0):
+        raise RouteTraceValidationError("identity must be RouteIdentityV0")
+    if not isinstance(trace.router_schema, RouterSchemaV0):
+        raise RouteTraceValidationError("router_schema must be RouterSchemaV0")
+    if not isinstance(trace.token_layout, RouteTokenLayoutV0):
+        raise RouteTraceValidationError("token_layout must be RouteTokenLayoutV0")
+    if not isinstance(trace.level, RouteTraceLevel):
+        raise RouteTraceValidationError("level must use the declared enum")
+    if trace.identity.router_schema_hash != trace.router_schema.fingerprint:
+        raise RouteTraceValidationError(
+            "router_schema_hash does not match the declared router schema"
+        )
+    if not isinstance(trace.topk_ids, Tensor):
+        raise RouteTraceValidationError("topk_ids must be a torch.Tensor")
+    if (
+        trace.topk_ids.layout is not torch.strided
+        or trace.topk_ids.device.type == "meta"
+    ):
+        raise RouteTraceValidationError(
+            "topk_ids must be a materialized strided tensor"
+        )
+
+    schema = trace.router_schema
+    token_count = trace.token_layout.token_count
+    expected_ids_shape = (token_count, schema.num_moe_layers, schema.top_k)
+    if tuple(trace.topk_ids.shape) != expected_ids_shape:
+        raise RouteTraceValidationError(
+            f"topk_ids shape must be {expected_ids_shape}, got {tuple(trace.topk_ids.shape)}"
+        )
+    expected_id_dtype = recommended_route_id_dtype(schema.num_experts)
+    if trace.topk_ids.dtype is not expected_id_dtype:
+        raise RouteTraceValidationError(
+            f"topk_ids must use compact dtype {expected_id_dtype}, got {trace.topk_ids.dtype}"
+        )
+
+    if trace.valid_mask is not None:
+        if not isinstance(trace.valid_mask, Tensor):
+            raise RouteTraceValidationError("valid_mask must be a torch.Tensor")
+        if (
+            trace.valid_mask.layout is not torch.strided
+            or trace.valid_mask.device.type == "meta"
+        ):
+            raise RouteTraceValidationError(
+                "valid_mask must be a materialized strided tensor"
+            )
+        if trace.valid_mask.dtype is not torch.bool or tuple(
+            trace.valid_mask.shape
+        ) != (token_count,):
+            raise RouteTraceValidationError(
+                f"valid_mask must be bool with shape {(token_count,)}"
+            )
+        if trace.valid_mask.device != trace.topk_ids.device:
+            raise RouteTraceValidationError(
+                "valid_mask must be on the same device as topk_ids"
+            )
+    mask = _effective_valid_mask(trace)
+    _validate_padding_mask(trace, mask)
+
+    ids64 = trace.topk_ids.to(dtype=torch.int64)
+    if ids64.numel() and (
+        ids64.min().item() < 0 or ids64.max().item() >= schema.num_experts
+    ):
+        raise RouteTraceValidationError(
+            "topk_ids contains an expert outside the declared range"
+        )
+    valid_rows = ids64[mask]
+    if schema.top_k > 1 and valid_rows.numel():
+        ordered_ids = valid_rows.sort(dim=-1).values
+        if bool((ordered_ids[..., 1:] == ordered_ids[..., :-1]).any().item()):
+            raise RouteTraceValidationError(
+                "topk_ids contains duplicate experts in a valid top-k row"
+            )
+    invalid_mask = ~mask
+    if (
+        invalid_mask.numel()
+        and bool(invalid_mask.any().item())
+        and bool(torch.count_nonzero(ids64[invalid_mask]).item())
+    ):
+        raise RouteTraceValidationError(
+            "invalid token rows must use canonical zero expert IDs"
+        )
+
+    rich_level = trace.level is RouteTraceLevel.IDS_WEIGHTS_MARGIN
+    if rich_level and (trace.selected_weights is None or trace.topk_margin is None):
+        raise RouteTraceValidationError(
+            "ids_weights_margin level requires weights and margins"
+        )
+    if not rich_level and (
+        trace.selected_weights is not None or trace.topk_margin is not None
+    ):
+        raise RouteTraceValidationError("ids level cannot carry weights or margins")
+
+    if trace.selected_weights is not None:
+        _validate_float_tensor(
+            "selected_weights",
+            trace.selected_weights,
+            expected_ids_shape,
+            trace.topk_ids.device,
+        )
+        valid_weights = trace.selected_weights.float()[mask]
+        if valid_weights.numel():
+            if not bool(torch.isfinite(valid_weights).all().item()) or bool(
+                (valid_weights < 0).any().item()
+            ):
+                raise RouteTraceValidationError(
+                    "selected_weights must be finite and non-negative"
+                )
+            weight_sums = valid_weights.sum(dim=-1)
+            if (
+                schema.selected_weight_semantics
+                is SelectedWeightSemantics.SELECTED_RENORMALIZED
+            ):
+                if not bool(
+                    torch.allclose(
+                        weight_sums, torch.ones_like(weight_sums), rtol=0, atol=5e-3
+                    )
+                ):
+                    raise RouteTraceValidationError(
+                        "renormalized selected weights must sum to one"
+                    )
+            elif bool(((weight_sums <= 0) | (weight_sums > 1.005)).any().item()):
+                raise RouteTraceValidationError(
+                    "full-softmax selected mass must be in (0, 1]"
+                )
+        if (
+            invalid_mask.numel()
+            and bool(invalid_mask.any().item())
+            and bool(torch.count_nonzero(trace.selected_weights[invalid_mask]).item())
+        ):
+            raise RouteTraceValidationError(
+                "invalid token rows must use canonical zero weights"
+            )
+
+    if trace.topk_margin is not None:
+        expected_margin_shape = (token_count, schema.num_moe_layers)
+        _validate_float_tensor(
+            "topk_margin",
+            trace.topk_margin,
+            expected_margin_shape,
+            trace.topk_ids.device,
+        )
+        valid_margins = trace.topk_margin.float()[mask]
+        if valid_margins.numel() and (
+            not bool(torch.isfinite(valid_margins).all().item())
+            or bool((valid_margins < 0).any().item())
+        ):
+            raise RouteTraceValidationError(
+                "topk_margin must be finite and non-negative"
+            )
+        if (
+            invalid_mask.numel()
+            and bool(invalid_mask.any().item())
+            and bool(torch.count_nonzero(trace.topk_margin[invalid_mask]).item())
+        ):
+            raise RouteTraceValidationError(
+                "invalid token rows must use canonical zero margins"
+            )
+
+
+def require_compatible_route_trace(
+    trace: RouteTraceV0,
+    *,
+    expected_identity: RouteIdentityV0,
+    expected_router_schema: RouterSchemaV0,
+    expected_token_layout: RouteTokenLayoutV0,
+    minimum_level: RouteTraceLevel = RouteTraceLevel.IDS,
+) -> None:
+    """Require exact replay identity and semantics at a consumer boundary."""
+    validate_route_trace(trace)
+    if trace.identity != expected_identity:
+        raise RouteTraceValidationError(
+            "route identity does not match the expected behavior artifact"
+        )
+    if trace.router_schema != expected_router_schema:
+        raise RouteTraceValidationError(
+            "router schema does not match the expected consumer schema"
+        )
+    if trace.token_layout != expected_token_layout:
+        raise RouteTraceValidationError(
+            "token layout does not match the expected consumer span"
+        )
+    if not isinstance(minimum_level, RouteTraceLevel):
+        raise RouteTraceValidationError("minimum_level must use the declared enum")
+    level_order = {RouteTraceLevel.IDS: 0, RouteTraceLevel.IDS_WEIGHTS_MARGIN: 1}
+    if level_order[trace.level] < level_order[minimum_level]:
+        raise RouteTraceValidationError(
+            f"trace level {trace.level.value} does not satisfy {minimum_level.value}"
+        )
+
+
+def require_semantically_aligned_traces(
+    behavior: RouteTraceV0, current: RouteTraceV0
+) -> None:
+    """Require two traces to share tensor interpretation and token alignment."""
+    validate_route_trace(behavior)
+    validate_route_trace(current)
+    if behavior.router_schema != current.router_schema:
+        raise RouteTraceValidationError(
+            "route metrics require an exact router schema match"
+        )
+    if behavior.token_layout != current.token_layout:
+        raise RouteTraceValidationError(
+            "route metrics require an exact token layout match"
+        )
+    if behavior.topk_ids.device != current.topk_ids.device:
+        raise RouteTraceValidationError(
+            "route metrics require tensors on the same device"
+        )
+    behavior_mask = _effective_valid_mask(behavior)
+    current_mask = _effective_valid_mask(current)
+    if not torch.equal(behavior_mask, current_mask):
+        raise RouteTraceValidationError(
+            "route metrics require identical validity masks"
+        )
+
+
+def _tensor_descriptor(tensor: Tensor) -> tuple[dict[str, Any], Tensor]:
+    if sys.byteorder != "little":
+        raise RouteTraceValidationError(
+            "route trace codec requires a little-endian host"
+        )
+    cpu_tensor = tensor.detach().contiguous().cpu()
+    raw_tensor = cpu_tensor.view(torch.uint8).reshape(-1).clone()
+    raw_bytes = raw_tensor.numpy().tobytes()
+    descriptor = {
+        "dtype": str(cpu_tensor.dtype).removeprefix("torch."),
+        "nbytes": len(raw_bytes),
+        "sha256": hashlib.sha256(raw_bytes).hexdigest(),
+        "shape": list(cpu_tensor.shape),
+    }
+    return descriptor, raw_tensor
+
+
+def _decode_tensor(name: str, descriptor: Any, raw_tensor: Tensor) -> Tensor:
+    descriptor = _require_exact_keys(
+        descriptor, {"dtype", "nbytes", "sha256", "shape"}, f"tensor descriptor {name}"
+    )
+    dtype_name = descriptor["dtype"]
+    if dtype_name not in _DTYPE_BY_NAME:
+        raise RouteTraceValidationError(
+            f"unsupported tensor dtype for {name}: {dtype_name!r}"
+        )
+    shape = descriptor["shape"]
+    if not isinstance(shape, list) or any(
+        isinstance(size, bool) or not isinstance(size, int) or size < 0
+        for size in shape
+    ):
+        raise RouteTraceValidationError(f"tensor shape for {name} is invalid")
+    nbytes = _require_int(f"tensor nbytes for {name}", descriptor["nbytes"], minimum=0)
+    _require_digest(f"tensor sha256 for {name}", descriptor["sha256"])
+    if raw_tensor.dtype is not torch.uint8 or raw_tensor.ndim != 1:
+        raise RouteTraceValidationError(
+            f"raw tensor for {name} must be one-dimensional uint8"
+        )
+    if raw_tensor.numel() != nbytes:
+        raise RouteTraceValidationError(
+            f"raw tensor size for {name} does not match its descriptor"
+        )
+    raw_bytes = raw_tensor.numpy().tobytes()
+    if hashlib.sha256(raw_bytes).hexdigest() != descriptor["sha256"]:
+        raise RouteTraceValidationError(f"raw tensor checksum mismatch for {name}")
+    dtype = _DTYPE_BY_NAME[dtype_name]
+    expected_nbytes = math.prod(shape) * torch.empty((), dtype=dtype).element_size()
+    if expected_nbytes != nbytes:
+        raise RouteTraceValidationError(
+            f"logical tensor size for {name} does not match its descriptor"
+        )
+    return raw_tensor.view(dtype).reshape(tuple(shape)).clone()
+
+
+class RouteTraceCodecV0:
+    """Safe bytes codec backed by safetensors and a strict JSON manifest.
+
+    Unsigned ID dtypes unsupported by older safetensors releases are stored as
+    raw uint8 buffers with checked logical dtype, shape, byte count, and SHA-256
+    descriptors. Decoding always returns detached CPU tensors and rejects
+    unknown fields, tensors, versions, trailing schema changes, and corruption.
+    """
+
+    @staticmethod
+    def dumps(trace: RouteTraceV0) -> bytes:
+        """Serialize a validated trace without pickle or executable objects."""
+        validate_route_trace(trace)
+        manifest: dict[str, Any] = {
+            "byte_order": "little",
+            "codec": _CODEC_NAME,
+            "identity": trace.identity.to_dict(),
+            "level": trace.level.value,
+            "route_trace_schema_version": ROUTE_TRACE_SCHEMA_VERSION,
+            "router_schema": trace.router_schema.to_dict(),
+            "tensors": {},
+            "token_layout": trace.token_layout.to_dict(),
+        }
+        buffers: dict[str, Tensor] = {}
+        for name in _TENSOR_NAMES:
+            tensor = getattr(trace, name)
+            if tensor is None:
+                continue
+            descriptor, raw_tensor = _tensor_descriptor(tensor)
+            manifest["tensors"][name] = descriptor
+            buffers[f"tensor.{name}"] = raw_tensor
+        manifest_bytes = _canonical_json_bytes(manifest)
+        if len(manifest_bytes) > _MAX_MANIFEST_BYTES:
+            raise RouteTraceValidationError(
+                "route trace manifest exceeds the size limit"
+            )
+        buffers[_MANIFEST_TENSOR] = torch.frombuffer(
+            bytearray(manifest_bytes), dtype=torch.uint8
+        ).clone()
+        try:
+            return safetensors.save(buffers)
+        except Exception as exc:
+            raise RouteTraceValidationError("failed to serialize route trace") from exc
+
+    @staticmethod
+    def loads(
+        data: bytes | bytearray | memoryview,
+        *,
+        max_serialized_bytes: int = _DEFAULT_MAX_SERIALIZED_BYTES,
+    ) -> RouteTraceV0:
+        """Decode and fully validate an untrusted route trace byte payload."""
+        _require_int("max_serialized_bytes", max_serialized_bytes, minimum=1)
+        if not isinstance(data, (bytes, bytearray, memoryview)):
+            raise RouteTraceValidationError("serialized route trace must be bytes-like")
+        data = bytes(data)
+        if len(data) > max_serialized_bytes:
+            raise RouteTraceValidationError(
+                "serialized route trace exceeds the size limit"
+            )
+        try:
+            tensors = safetensors.load(data)
+        except Exception as exc:
+            raise RouteTraceValidationError(
+                "invalid safetensors route trace container"
+            ) from exc
+        if _MANIFEST_TENSOR not in tensors:
+            raise RouteTraceValidationError("route trace manifest tensor is missing")
+        manifest_tensor = tensors[_MANIFEST_TENSOR]
+        if manifest_tensor.dtype is not torch.uint8 or manifest_tensor.ndim != 1:
+            raise RouteTraceValidationError(
+                "route trace manifest tensor must be one-dimensional uint8"
+            )
+        if manifest_tensor.numel() > _MAX_MANIFEST_BYTES:
+            raise RouteTraceValidationError(
+                "route trace manifest exceeds the size limit"
+            )
+        try:
+            manifest = json.loads(bytes(manifest_tensor.tolist()).decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise RouteTraceValidationError(
+                "route trace manifest is not valid UTF-8 JSON"
+            ) from exc
+        manifest = _require_exact_keys(
+            manifest,
+            {
+                "byte_order",
+                "codec",
+                "identity",
+                "level",
+                "route_trace_schema_version",
+                "router_schema",
+                "tensors",
+                "token_layout",
+            },
+            "route trace manifest",
+        )
+        if manifest["byte_order"] != "little" or sys.byteorder != "little":
+            raise RouteTraceValidationError(
+                f"unsupported route trace byte order: {manifest['byte_order']!r}"
+            )
+        if manifest["codec"] != _CODEC_NAME:
+            raise RouteTraceValidationError(
+                f"unsupported route trace codec: {manifest['codec']!r}"
+            )
+        try:
+            _require_int(
+                "route_trace_schema_version",
+                manifest["route_trace_schema_version"],
+                minimum=ROUTE_TRACE_SCHEMA_VERSION,
+                maximum=ROUTE_TRACE_SCHEMA_VERSION,
+            )
+        except RouteTraceValidationError as exc:
+            raise RouteTraceValidationError(
+                f"unsupported route trace schema version: {manifest['route_trace_schema_version']!r}"
+            ) from exc
+        tensor_descriptors = manifest["tensors"]
+        if not isinstance(tensor_descriptors, Mapping):
+            raise RouteTraceValidationError(
+                "route trace tensor table must be a mapping"
+            )
+        unknown_tensor_names = set(tensor_descriptors) - set(_TENSOR_NAMES)
+        if unknown_tensor_names:
+            raise RouteTraceValidationError(
+                f"route trace contains unknown logical tensors: {sorted(unknown_tensor_names)}"
+            )
+        expected_container_names = {_MANIFEST_TENSOR} | {
+            f"tensor.{name}" for name in tensor_descriptors
+        }
+        if set(tensors) != expected_container_names:
+            raise RouteTraceValidationError(
+                "route trace container tensor names do not match the manifest"
+            )
+        decoded = {
+            name: _decode_tensor(name, descriptor, tensors[f"tensor.{name}"])
+            for name, descriptor in tensor_descriptors.items()
+        }
+        return RouteTraceV0(
+            identity=RouteIdentityV0.from_dict(manifest["identity"]),
+            router_schema=RouterSchemaV0.from_dict(manifest["router_schema"]),
+            token_layout=RouteTokenLayoutV0.from_dict(manifest["token_layout"]),
+            level=_parse_enum(RouteTraceLevel, "level", manifest["level"]),
+            topk_ids=decoded.get("topk_ids"),
+            selected_weights=decoded.get("selected_weights"),
+            topk_margin=decoded.get("topk_margin"),
+            valid_mask=decoded.get("valid_mask"),
+        )

--- a/astrai/trainer/rollout.py
+++ b/astrai/trainer/rollout.py
@@ -23,6 +23,10 @@ from torch import Tensor
 
 from astrai.inference.scheduler import InferenceScheduler
 from astrai.inference.task import GenerationResult
+from astrai.trainer.route_trace import (
+    RolloutRouteTraceBatchV0,
+    RolloutRouteTraceError,
+)
 
 
 @dataclass(kw_only=True)
@@ -47,6 +51,8 @@ class RawRollout:
             need text).
         response_texts: Decoded response strings, shape ``[B, G]``
             (for reward models).
+        route_trace_batch: Optional immutable MoE route artifacts bound to the
+            exact policy version and prompt/response token tensors.
     """
 
     prompts: Tensor
@@ -57,6 +63,7 @@ class RawRollout:
     policy_version: int = 0
     prompt_texts: List[str] = field(default_factory=list)
     response_texts: List[List[str]] = field(default_factory=list)
+    route_trace_batch: Optional[RolloutRouteTraceBatchV0] = None
 
 
 @dataclass(kw_only=True)
@@ -492,6 +499,7 @@ class RolloutRunner:
             policy_version=raw.policy_version,
             prompt_texts=raw.prompt_texts,
             response_texts=raw.response_texts,
+            route_trace_batch=raw.route_trace_batch,
         )
 
     def _validate_policy_version(
@@ -512,6 +520,20 @@ class RolloutRunner:
             raise RolloutVersionError(
                 f"rollout policy lag {lag} exceeds max_policy_lag="
                 f"{self.max_policy_lag} (rollout={version}, live={live_version})"
+            )
+        route_trace_batch = result.route_trace_batch
+        if route_trace_batch is not None:
+            if not isinstance(route_trace_batch, RolloutRouteTraceBatchV0):
+                raise RolloutRouteTraceError(
+                    "route_trace_batch must use RolloutRouteTraceBatchV0"
+                )
+            route_trace_batch.validate_against(
+                policy_version=version,
+                prompts=result.prompts,
+                prompt_mask=result.prompt_mask,
+                responses=result.responses,
+                response_mask=result.response_mask,
+                logprobs_old=result.logprobs_old,
             )
 
     def __call__(self, batch: Dict[str, Tensor]) -> Tuple[RolloutResult, bool]:

--- a/astrai/trainer/route_trace.py
+++ b/astrai/trainer/route_trace.py
@@ -1,0 +1,580 @@
+"""Immutable binding between MoE route traces and online rollout tokens.
+
+The model-side capture path is deliberately outside this module. A producer
+that already has one :class:`~astrai.moe.RouteTraceV0` per generated response
+can use :meth:`RolloutRouteTraceBatchV0.bind` to attach those artifacts to a
+rollout. The resulting payloads are immutable bytes, and every cache boundary
+can validate their policy and token identity without decoding large route
+tensors again.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+from torch import Tensor
+
+from astrai.moe import (
+    PaddingLayout,
+    RouteIdentityV0,
+    RouterSchemaV0,
+    RouteTokenLayoutV0,
+    RouteTraceCodecV0,
+    RouteTraceLevel,
+    RouteTraceV0,
+    RouteTraceValidationError,
+    TokenSpanKind,
+    canonical_json_digest,
+    validate_route_trace,
+)
+
+ROLLOUT_ROUTE_TRACE_SCHEMA_VERSION = 0
+
+_SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
+
+__all__ = [
+    "ROLLOUT_ROUTE_TRACE_SCHEMA_VERSION",
+    "RolloutRouteTraceBatchV0",
+    "RolloutRouteTraceError",
+    "RolloutRouteTraceItemV0",
+    "rollout_route_sample_id",
+]
+
+
+class RolloutRouteTraceError(RouteTraceValidationError):
+    """A route-trace batch cannot be attributed to its rollout tokens."""
+
+
+def _require_int(name: str, value: Any, *, minimum: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise RolloutRouteTraceError(f"{name} must be an integer >= {minimum}")
+    return value
+
+
+def _require_text(name: str, value: Any) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value or len(value) > 1024:
+        raise RolloutRouteTraceError(f"{name} must be a non-empty bounded string")
+    return value
+
+
+def _require_digest(name: str, value: Any) -> str:
+    if not isinstance(value, str) or _SHA256_PATTERN.fullmatch(value) is None:
+        raise RolloutRouteTraceError(f"{name} must be a lowercase SHA-256 digest")
+    return value
+
+
+def rollout_route_sample_id(rollout_id: str, batch_index: int, group_index: int) -> str:
+    """Derive the only valid per-response sample ID for a rollout grid cell."""
+    _require_text("rollout_id", rollout_id)
+    _require_int("batch_index", batch_index, minimum=0)
+    _require_int("group_index", group_index, minimum=0)
+    return canonical_json_digest(
+        {
+            "batch_index": batch_index,
+            "group_index": group_index,
+            "rollout_id": rollout_id,
+            "schema_version": ROLLOUT_ROUTE_TRACE_SCHEMA_VERSION,
+        }
+    )
+
+
+def _tensor_digest(name: str, tensor: Tensor) -> str:
+    if not isinstance(tensor, Tensor):
+        raise RolloutRouteTraceError(f"{name} must be a torch.Tensor")
+    if tensor.layout is not torch.strided or tensor.device.type == "meta":
+        raise RolloutRouteTraceError(f"{name} must be a materialized strided tensor")
+    if tensor.requires_grad:
+        raise RolloutRouteTraceError(f"{name} must be detached from autograd")
+    if sys.byteorder != "little":
+        raise RolloutRouteTraceError(
+            "rollout trace binding requires little-endian tensors"
+        )
+    cpu_tensor = tensor.detach().contiguous().cpu()
+    raw = cpu_tensor.view(torch.uint8).reshape(-1).numpy().tobytes()
+    return canonical_json_digest(
+        {
+            "byte_order": "little",
+            "dtype": str(cpu_tensor.dtype).removeprefix("torch."),
+            "payload_sha256": hashlib.sha256(raw).hexdigest(),
+            "shape": list(cpu_tensor.shape),
+        }
+    )
+
+
+def _effective_mask(trace: RouteTraceV0) -> Tensor:
+    if trace.valid_mask is not None:
+        return trace.valid_mask.detach().cpu()
+    return torch.ones(trace.token_layout.token_count, dtype=torch.bool)
+
+
+def _validate_rollout_tensors(
+    *,
+    prompts: Tensor,
+    prompt_mask: Tensor,
+    responses: Tensor,
+    response_mask: Tensor,
+    logprobs_old: Tensor,
+) -> tuple[int, int, int, int, str, str, str]:
+    tensors = {
+        "prompts": prompts,
+        "prompt_mask": prompt_mask,
+        "responses": responses,
+        "response_mask": response_mask,
+        "logprobs_old": logprobs_old,
+    }
+    for name, tensor in tensors.items():
+        if not isinstance(tensor, Tensor):
+            raise RolloutRouteTraceError(f"{name} must be a torch.Tensor")
+        if tensor.layout is not torch.strided or tensor.device.type == "meta":
+            raise RolloutRouteTraceError(
+                f"{name} must be a materialized strided tensor"
+            )
+        if tensor.requires_grad:
+            raise RolloutRouteTraceError(f"{name} must be detached from autograd")
+
+    if prompts.dtype is not torch.long or prompts.ndim != 2:
+        raise RolloutRouteTraceError("prompts must be int64 with shape [B, P]")
+    if responses.dtype is not torch.long or responses.ndim != 3:
+        raise RolloutRouteTraceError("responses must be int64 with shape [B, G, R]")
+    if prompt_mask.dtype is not torch.bool or prompt_mask.shape != prompts.shape:
+        raise RolloutRouteTraceError("prompt_mask must be bool with shape [B, P]")
+    if response_mask.dtype is not torch.bool or response_mask.shape != responses.shape:
+        raise RolloutRouteTraceError("response_mask must be bool with shape [B, G, R]")
+    if not logprobs_old.is_floating_point() or logprobs_old.shape != responses.shape:
+        raise RolloutRouteTraceError(
+            "logprobs_old must be floating with shape [B, G, R]"
+        )
+    if len({tensor.device for tensor in tensors.values()}) != 1:
+        raise RolloutRouteTraceError(
+            "rollout token tensors and masks must share one device"
+        )
+
+    batch_size, prompt_width = prompts.shape
+    response_batch_size, group_size, response_width = responses.shape
+    if batch_size < 1 or group_size < 1 or prompt_width < 1 or response_width < 1:
+        raise RolloutRouteTraceError(
+            "rollout token tensors require positive B, G, P, and R dimensions"
+        )
+    if response_batch_size != batch_size:
+        raise RolloutRouteTraceError("prompt and response batch dimensions differ")
+    if not bool(prompt_mask.any(dim=-1).all().item()):
+        raise RolloutRouteTraceError("each rollout prompt must contain a valid token")
+
+    if prompt_width > 1 and bool(
+        (prompt_mask[:, :-1] & ~prompt_mask[:, 1:]).any().item()
+    ):
+        raise RolloutRouteTraceError(
+            "prompt_mask must use canonical left-padding order"
+        )
+    if response_width > 1 and bool(
+        ((~response_mask[..., :-1]) & response_mask[..., 1:]).any().item()
+    ):
+        raise RolloutRouteTraceError(
+            "response_mask must use canonical right-padding order"
+        )
+    if bool(torch.count_nonzero(prompts[~prompt_mask]).item()):
+        raise RolloutRouteTraceError("padded prompt token IDs must be canonical zero")
+    if bool(torch.count_nonzero(responses[~response_mask]).item()):
+        raise RolloutRouteTraceError("padded response token IDs must be canonical zero")
+    if bool((prompts[prompt_mask] < 0).any().item()) or bool(
+        (responses[response_mask] < 0).any().item()
+    ):
+        raise RolloutRouteTraceError("valid rollout token IDs must be non-negative")
+    if not bool(torch.isfinite(logprobs_old[response_mask]).all().item()):
+        raise RolloutRouteTraceError(
+            "valid behavior logprobs must contain only finite values"
+        )
+    if bool((logprobs_old[response_mask] > 0).any().item()):
+        raise RolloutRouteTraceError("valid behavior logprobs must be non-positive")
+    padded_logprobs = logprobs_old[~response_mask]
+    if padded_logprobs.numel() and (
+        bool(torch.count_nonzero(padded_logprobs).item())
+        or bool(torch.signbit(padded_logprobs).any().item())
+    ):
+        raise RolloutRouteTraceError(
+            "padded behavior logprobs must use canonical positive zero"
+        )
+
+    prompt_batch_digest = canonical_json_digest(
+        {
+            "prompt_mask": _tensor_digest("prompt_mask", prompt_mask),
+            "prompts": _tensor_digest("prompts", prompts),
+        }
+    )
+    response_batch_digest = canonical_json_digest(
+        {
+            "response_mask": _tensor_digest("response_mask", response_mask),
+            "responses": _tensor_digest("responses", responses),
+        }
+    )
+    behavior_logprobs_digest = _tensor_digest("logprobs_old", logprobs_old)
+    return (
+        batch_size,
+        group_size,
+        prompt_width,
+        response_width,
+        prompt_batch_digest,
+        response_batch_digest,
+        behavior_logprobs_digest,
+    )
+
+
+@dataclass(frozen=True)
+class RolloutRouteTraceItemV0:
+    """One immutable serialized trace and its verified lightweight header."""
+
+    payload: bytes = field(repr=False)
+    artifact_digest: str
+    identity: RouteIdentityV0
+    router_schema: RouterSchemaV0
+    token_layout: RouteTokenLayoutV0
+    level: RouteTraceLevel
+    valid_mask_digest: str
+
+    def __post_init__(self) -> None:
+        if type(self.payload) is not bytes:
+            raise RolloutRouteTraceError("route trace payload must be immutable bytes")
+        _require_digest("artifact_digest", self.artifact_digest)
+        _require_digest("valid_mask_digest", self.valid_mask_digest)
+        if hashlib.sha256(self.payload).hexdigest() != self.artifact_digest:
+            raise RolloutRouteTraceError("route trace payload digest does not match")
+        try:
+            decoded = RouteTraceCodecV0.loads(self.payload)
+        except RouteTraceValidationError as exc:
+            raise RolloutRouteTraceError("route trace payload is invalid") from exc
+        if decoded.identity != self.identity:
+            raise RolloutRouteTraceError("route trace identity header does not match")
+        if decoded.router_schema != self.router_schema:
+            raise RolloutRouteTraceError("route trace schema header does not match")
+        if decoded.token_layout != self.token_layout:
+            raise RolloutRouteTraceError("route trace token header does not match")
+        if decoded.level is not self.level:
+            raise RolloutRouteTraceError("route trace level header does not match")
+        if (
+            _tensor_digest("route trace valid mask", _effective_mask(decoded))
+            != self.valid_mask_digest
+        ):
+            raise RolloutRouteTraceError("route trace validity header does not match")
+
+    @classmethod
+    def from_trace(cls, trace: RouteTraceV0) -> RolloutRouteTraceItemV0:
+        """Freeze one validated trace into immutable transport bytes."""
+        if not isinstance(trace, RouteTraceV0):
+            raise RolloutRouteTraceError("route trace item must be RouteTraceV0")
+        validate_route_trace(trace)
+        payload = RouteTraceCodecV0.dumps(trace)
+        return cls(
+            payload=payload,
+            artifact_digest=hashlib.sha256(payload).hexdigest(),
+            identity=trace.identity,
+            router_schema=trace.router_schema,
+            token_layout=trace.token_layout,
+            level=trace.level,
+            valid_mask_digest=_tensor_digest(
+                "route trace valid mask", _effective_mask(trace)
+            ),
+        )
+
+    def decode(self) -> RouteTraceV0:
+        """Decode a fresh CPU trace after verifying immutable content identity."""
+        if hashlib.sha256(self.payload).hexdigest() != self.artifact_digest:
+            raise RolloutRouteTraceError("route trace payload digest does not match")
+        return RouteTraceCodecV0.loads(self.payload)
+
+    def manifest(self) -> dict[str, Any]:
+        """Return a JSON-compatible header without copying the tensor payload."""
+        return {
+            "artifact_digest": self.artifact_digest,
+            "identity": self.identity.to_dict(),
+            "level": self.level.value,
+            "payload_nbytes": len(self.payload),
+            "router_schema": self.router_schema.to_dict(),
+            "token_layout": self.token_layout.to_dict(),
+            "valid_mask_digest": self.valid_mask_digest,
+        }
+
+
+@dataclass(frozen=True)
+class RolloutRouteTraceBatchV0:
+    """A content-addressed B-by-G grid bound to one rollout token batch."""
+
+    rollout_id: str
+    policy_version: int
+    prompt_batch_digest: str
+    response_batch_digest: str
+    behavior_logprobs_digest: str
+    items: tuple[tuple[RolloutRouteTraceItemV0, ...], ...]
+    schema_version: int = ROLLOUT_ROUTE_TRACE_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        _require_int("schema_version", self.schema_version, minimum=0)
+        if self.schema_version != ROLLOUT_ROUTE_TRACE_SCHEMA_VERSION:
+            raise RolloutRouteTraceError(
+                f"unsupported rollout route trace schema version {self.schema_version}"
+            )
+        _require_text("rollout_id", self.rollout_id)
+        _require_int("policy_version", self.policy_version, minimum=0)
+        _require_digest("prompt_batch_digest", self.prompt_batch_digest)
+        _require_digest("response_batch_digest", self.response_batch_digest)
+        _require_digest("behavior_logprobs_digest", self.behavior_logprobs_digest)
+        if type(self.items) is not tuple or not self.items:
+            raise RolloutRouteTraceError(
+                "route trace items must be a non-empty tuple grid"
+            )
+        if any(type(row) is not tuple or not row for row in self.items):
+            raise RolloutRouteTraceError(
+                "each route trace item row must be a non-empty tuple"
+            )
+        group_size = len(self.items[0])
+        if any(len(row) != group_size for row in self.items):
+            raise RolloutRouteTraceError(
+                "route trace item rows have unequal group sizes"
+            )
+
+        first = self.items[0][0]
+        if not isinstance(first, RolloutRouteTraceItemV0):
+            raise RolloutRouteTraceError(
+                "route trace item grid contains an invalid item"
+            )
+        sample_ids: set[str] = set()
+        for row in self.items:
+            for item in row:
+                if not isinstance(item, RolloutRouteTraceItemV0):
+                    raise RolloutRouteTraceError(
+                        "route trace item grid contains an invalid item"
+                    )
+                if item.identity.policy_version != self.policy_version:
+                    raise RolloutRouteTraceError(
+                        "route trace policy version does not match its batch"
+                    )
+                if item.identity != first.identity:
+                    raise RolloutRouteTraceError(
+                        "one rollout trace batch cannot mix behavior identities"
+                    )
+                if item.router_schema != first.router_schema:
+                    raise RolloutRouteTraceError(
+                        "one rollout trace batch cannot mix router schemas"
+                    )
+                if item.level is not first.level:
+                    raise RolloutRouteTraceError(
+                        "one rollout trace batch cannot mix trace levels"
+                    )
+                sample_id = item.token_layout.sample_id
+                if sample_id in sample_ids:
+                    raise RolloutRouteTraceError(
+                        "route trace sample IDs must be unique within a rollout"
+                    )
+                sample_ids.add(sample_id)
+
+    @property
+    def batch_size(self) -> int:
+        return len(self.items)
+
+    @property
+    def group_size(self) -> int:
+        return len(self.items[0])
+
+    @property
+    def identity(self) -> RouteIdentityV0:
+        return self.items[0][0].identity
+
+    @property
+    def router_schema(self) -> RouterSchemaV0:
+        return self.items[0][0].router_schema
+
+    @property
+    def level(self) -> RouteTraceLevel:
+        return self.items[0][0].level
+
+    @property
+    def artifact_digest(self) -> str:
+        """Return the content address of token identity and ordered trace IDs."""
+        return canonical_json_digest(self.manifest())
+
+    @property
+    def payload_nbytes(self) -> int:
+        """Return the exact combined serialized trace bytes in this batch."""
+        return sum(len(item.payload) for row in self.items for item in row)
+
+    @classmethod
+    def bind(
+        cls,
+        *,
+        rollout_id: str,
+        policy_version: int,
+        prompts: Tensor,
+        prompt_mask: Tensor,
+        responses: Tensor,
+        response_mask: Tensor,
+        logprobs_old: Tensor,
+        traces: Sequence[Sequence[RouteTraceV0]],
+    ) -> RolloutRouteTraceBatchV0:
+        """Freeze traces and bind them to an exact rollout tensor identity."""
+        (
+            batch_size,
+            group_size,
+            _,
+            _,
+            prompt_batch_digest,
+            response_batch_digest,
+            behavior_logprobs_digest,
+        ) = _validate_rollout_tensors(
+            prompts=prompts,
+            prompt_mask=prompt_mask,
+            responses=responses,
+            response_mask=response_mask,
+            logprobs_old=logprobs_old,
+        )
+        if isinstance(traces, (str, bytes)) or not isinstance(traces, Sequence):
+            raise RolloutRouteTraceError("traces must be a rectangular sequence grid")
+        if any(
+            isinstance(row, (str, bytes)) or not isinstance(row, Sequence)
+            for row in traces
+        ):
+            raise RolloutRouteTraceError("traces must be a rectangular sequence grid")
+        if len(traces) != batch_size or any(len(row) != group_size for row in traces):
+            raise RolloutRouteTraceError(
+                "rollout B/G dimensions do not match the route trace grid"
+            )
+        if any(not isinstance(trace, RouteTraceV0) for row in traces for trace in row):
+            raise RolloutRouteTraceError("route trace item must be RouteTraceV0")
+        items = tuple(
+            tuple(RolloutRouteTraceItemV0.from_trace(trace) for trace in row)
+            for row in traces
+        )
+        batch = cls(
+            rollout_id=rollout_id,
+            policy_version=policy_version,
+            prompt_batch_digest=prompt_batch_digest,
+            response_batch_digest=response_batch_digest,
+            behavior_logprobs_digest=behavior_logprobs_digest,
+            items=items,
+        )
+        batch.validate_against(
+            policy_version=policy_version,
+            prompts=prompts,
+            prompt_mask=prompt_mask,
+            responses=responses,
+            response_mask=response_mask,
+            logprobs_old=logprobs_old,
+        )
+        return batch
+
+    def validate_against(
+        self,
+        *,
+        policy_version: int,
+        prompts: Tensor,
+        prompt_mask: Tensor,
+        responses: Tensor,
+        response_mask: Tensor,
+        logprobs_old: Tensor,
+    ) -> None:
+        """Require exact policy, token bytes, grid, boundary, and mask identity."""
+        _require_int("policy_version", policy_version, minimum=0)
+        if policy_version != self.policy_version:
+            raise RolloutRouteTraceError(
+                "rollout policy version does not match its route trace batch"
+            )
+        (
+            batch_size,
+            group_size,
+            _,
+            response_width,
+            prompt_batch_digest,
+            response_batch_digest,
+            behavior_logprobs_digest,
+        ) = _validate_rollout_tensors(
+            prompts=prompts,
+            prompt_mask=prompt_mask,
+            responses=responses,
+            response_mask=response_mask,
+            logprobs_old=logprobs_old,
+        )
+        if (batch_size, group_size) != (self.batch_size, self.group_size):
+            raise RolloutRouteTraceError(
+                "rollout B/G dimensions do not match the route trace grid"
+            )
+        if prompt_batch_digest != self.prompt_batch_digest:
+            raise RolloutRouteTraceError(
+                "rollout prompt tokens do not match the route trace binding"
+            )
+        if response_batch_digest != self.response_batch_digest:
+            raise RolloutRouteTraceError(
+                "rollout response tokens do not match the route trace binding"
+            )
+        if behavior_logprobs_digest != self.behavior_logprobs_digest:
+            raise RolloutRouteTraceError(
+                "behavior logprobs do not match the route trace binding"
+            )
+
+        prompt_lengths = prompt_mask.sum(dim=-1).detach().cpu().tolist()
+        response_masks = response_mask.detach().cpu()
+        for batch_index, row in enumerate(self.items):
+            prompt_length = int(prompt_lengths[batch_index])
+            for group_index, item in enumerate(row):
+                layout = item.token_layout
+                if layout.sample_id != rollout_route_sample_id(
+                    self.rollout_id, batch_index, group_index
+                ):
+                    raise RolloutRouteTraceError(
+                        "route trace sample ID does not match its rollout grid position"
+                    )
+                expected_layout = {
+                    "prompt_token_count": prompt_length,
+                    "sequence_token_count": prompt_length + response_width,
+                    "span_kind": TokenSpanKind.RESPONSE,
+                    "token_count": response_width,
+                    "token_offset": prompt_length,
+                }
+                actual_layout = {
+                    "prompt_token_count": layout.prompt_token_count,
+                    "sequence_token_count": layout.sequence_token_count,
+                    "span_kind": layout.span_kind,
+                    "token_count": layout.token_count,
+                    "token_offset": layout.token_offset,
+                }
+                if actual_layout != expected_layout:
+                    raise RolloutRouteTraceError(
+                        "route trace token boundaries do not match the rollout response"
+                    )
+                expected_mask = response_masks[batch_index, group_index]
+                if (
+                    _tensor_digest("response route mask", expected_mask)
+                    != item.valid_mask_digest
+                ):
+                    raise RolloutRouteTraceError(
+                        "route trace validity mask does not match the rollout response"
+                    )
+                if bool(
+                    (~expected_mask).any().item()
+                ) and item.router_schema.padding_layout not in (
+                    PaddingLayout.RIGHT,
+                    PaddingLayout.EXPLICIT_MASK,
+                ):
+                    raise RolloutRouteTraceError(
+                        "padded rollout responses require right or explicit trace padding"
+                    )
+
+    def decode_traces(self) -> tuple[tuple[RouteTraceV0, ...], ...]:
+        """Decode fresh CPU trace objects while preserving B/G ordering."""
+        return tuple(tuple(item.decode() for item in row) for row in self.items)
+
+    def manifest(self) -> dict[str, Any]:
+        """Return a strict JSON-compatible identity manifest without payloads."""
+        return {
+            "items": [[item.manifest() for item in row] for row in self.items],
+            "behavior_logprobs_digest": self.behavior_logprobs_digest,
+            "payload_nbytes": self.payload_nbytes,
+            "policy_version": self.policy_version,
+            "prompt_batch_digest": self.prompt_batch_digest,
+            "response_batch_digest": self.response_batch_digest,
+            "rollout_id": self.rollout_id,
+            "schema_version": self.schema_version,
+        }

--- a/astrai/trainer/route_trace.py
+++ b/astrai/trainer/route_trace.py
@@ -281,6 +281,38 @@ class RolloutRouteTraceItemV0:
             ),
         )
 
+    @classmethod
+    def from_payload(
+        cls,
+        payload: bytes | bytearray | memoryview,
+        *,
+        max_serialized_bytes: int,
+    ) -> RolloutRouteTraceItemV0:
+        """Build a verified item from an untrusted serialized trace payload."""
+        if not isinstance(payload, (bytes, bytearray, memoryview)):
+            raise RolloutRouteTraceError("route trace payload must be bytes-like")
+        payload = bytes(payload)
+        try:
+            trace = RouteTraceCodecV0.loads(
+                payload,
+                max_serialized_bytes=max_serialized_bytes,
+            )
+        except RouteTraceValidationError as exc:
+            raise RolloutRouteTraceError(
+                f"route trace payload is invalid: {exc}"
+            ) from exc
+        return cls(
+            payload=payload,
+            artifact_digest=hashlib.sha256(payload).hexdigest(),
+            identity=trace.identity,
+            router_schema=trace.router_schema,
+            token_layout=trace.token_layout,
+            level=trace.level,
+            valid_mask_digest=_tensor_digest(
+                "route trace valid mask", _effective_mask(trace)
+            ),
+        )
+
     def decode(self) -> RouteTraceV0:
         """Decode a fresh CPU trace after verifying immutable content identity."""
         if hashlib.sha256(self.payload).hexdigest() != self.artifact_digest:

--- a/astrai/trainer/route_trace_transport.py
+++ b/astrai/trainer/route_trace_transport.py
@@ -1,0 +1,824 @@
+"""Bounded, content-addressed shards for rollout route-trace transport.
+
+The transport layer splits an already validated
+:class:`~astrai.trainer.route_trace.RolloutRouteTraceBatchV0` into independently
+verifiable byte frames. It does not prescribe Ray, NCCL, shared-memory, or
+filesystem delivery. Receivers can validate one assigned shard without loading
+the other route tensors and can only reconstruct a batch after every declared
+shard is present and matches the original batch digest.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import struct
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from astrai.moe import canonical_json_digest
+from astrai.trainer.route_trace import (
+    ROLLOUT_ROUTE_TRACE_SCHEMA_VERSION,
+    RolloutRouteTraceBatchV0,
+    RolloutRouteTraceError,
+    RolloutRouteTraceItemV0,
+)
+
+ROLLOUT_ROUTE_TRACE_SHARD_SCHEMA_VERSION = 0
+DEFAULT_ROUTE_TRACE_SHARD_BYTES = 16 * 1024 * 1024
+DEFAULT_ROUTE_TRACE_SHARD_ITEMS = 128
+DEFAULT_ROUTE_TRACE_TRANSPORT_BYTES = 1024 * 1024 * 1024
+
+_FRAME_MAGIC = b"ARTRSHD0"
+_FRAME_PREFIX = struct.Struct(">8sI")
+_MAX_HEADER_BYTES = 8 * 1024 * 1024
+_MAX_MANIFEST_BYTES = 16 * 1024 * 1024
+_MAX_SHARD_COUNT = 131_072
+_MAX_ITEMS_PER_SHARD = 65_536
+_SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
+
+__all__ = [
+    "DEFAULT_ROUTE_TRACE_SHARD_BYTES",
+    "DEFAULT_ROUTE_TRACE_SHARD_ITEMS",
+    "DEFAULT_ROUTE_TRACE_TRANSPORT_BYTES",
+    "ROLLOUT_ROUTE_TRACE_SHARD_SCHEMA_VERSION",
+    "RolloutRouteTraceShardCodecV0",
+    "RolloutRouteTraceShardDescriptorV0",
+    "RolloutRouteTraceShardManifestV0",
+    "RolloutRouteTraceShardV0",
+    "RolloutRouteTraceTransportV0",
+]
+
+
+def _require_int(
+    name: str,
+    value: Any,
+    *,
+    minimum: int,
+    maximum: int | None = None,
+) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise RolloutRouteTraceError(f"{name} must be an integer >= {minimum}")
+    if maximum is not None and value > maximum:
+        raise RolloutRouteTraceError(f"{name} must be <= {maximum}")
+    return value
+
+
+def _require_text(name: str, value: Any) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value or len(value) > 1024:
+        raise RolloutRouteTraceError(f"{name} must be a non-empty bounded string")
+    return value
+
+
+def _require_digest(name: str, value: Any) -> str:
+    if not isinstance(value, str) or _SHA256_PATTERN.fullmatch(value) is None:
+        raise RolloutRouteTraceError(f"{name} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _require_exact_keys(
+    value: Any,
+    expected: set[str],
+    label: str,
+) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise RolloutRouteTraceError(f"{label} must be a mapping")
+    keys = set(value)
+    if keys != expected:
+        raise RolloutRouteTraceError(
+            f"{label} keys do not match version-zero schema; "
+            f"missing={sorted(expected - keys)}, unknown={sorted(keys - expected)}"
+        )
+    return value
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    try:
+        rendered = json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError) as exc:
+        raise RolloutRouteTraceError(
+            "route shard metadata is not canonical-JSON serializable"
+        ) from exc
+    return rendered.encode("utf-8")
+
+
+def _decode_json_object(data: bytes, *, label: str) -> Mapping[str, Any]:
+    try:
+        value = json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise RolloutRouteTraceError(f"{label} is not valid UTF-8 JSON") from exc
+    if not isinstance(value, Mapping):
+        raise RolloutRouteTraceError(f"{label} must contain a JSON object")
+    if _canonical_json_bytes(value) != data:
+        raise RolloutRouteTraceError(f"{label} must use canonical JSON encoding")
+    return value
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+@dataclass(frozen=True)
+class RolloutRouteTraceShardDescriptorV0:
+    """Payload-free identity and range of one encoded shard."""
+
+    shard_index: int
+    first_flat_index: int
+    item_count: int
+    payload_nbytes: int
+    encoded_nbytes: int
+    encoded_sha256: str
+
+    def __post_init__(self) -> None:
+        _require_int("shard_index", self.shard_index, minimum=0)
+        _require_int("first_flat_index", self.first_flat_index, minimum=0)
+        _require_int(
+            "item_count",
+            self.item_count,
+            minimum=1,
+            maximum=_MAX_ITEMS_PER_SHARD,
+        )
+        _require_int("payload_nbytes", self.payload_nbytes, minimum=1)
+        _require_int(
+            "encoded_nbytes",
+            self.encoded_nbytes,
+            minimum=_FRAME_PREFIX.size + 2,
+        )
+        if self.encoded_nbytes <= self.payload_nbytes:
+            raise RolloutRouteTraceError(
+                "encoded_nbytes must include metadata beyond the item payloads"
+            )
+        _require_digest("encoded_sha256", self.encoded_sha256)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "encoded_nbytes": self.encoded_nbytes,
+            "encoded_sha256": self.encoded_sha256,
+            "first_flat_index": self.first_flat_index,
+            "item_count": self.item_count,
+            "payload_nbytes": self.payload_nbytes,
+            "shard_index": self.shard_index,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> RolloutRouteTraceShardDescriptorV0:
+        fields = {
+            "encoded_nbytes",
+            "encoded_sha256",
+            "first_flat_index",
+            "item_count",
+            "payload_nbytes",
+            "shard_index",
+        }
+        value = _require_exact_keys(value, fields, "route shard descriptor")
+        return cls(**{name: value[name] for name in fields})
+
+
+@dataclass(frozen=True)
+class RolloutRouteTraceShardV0:
+    """Decoded items from one independently authenticated shard frame."""
+
+    batch_artifact_digest: str
+    batch_size: int
+    group_size: int
+    shard_index: int
+    first_flat_index: int
+    items: tuple[RolloutRouteTraceItemV0, ...]
+    schema_version: int = ROLLOUT_ROUTE_TRACE_SHARD_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        _require_int(
+            "schema_version",
+            self.schema_version,
+            minimum=ROLLOUT_ROUTE_TRACE_SHARD_SCHEMA_VERSION,
+            maximum=ROLLOUT_ROUTE_TRACE_SHARD_SCHEMA_VERSION,
+        )
+        _require_digest("batch_artifact_digest", self.batch_artifact_digest)
+        _require_int("batch_size", self.batch_size, minimum=1)
+        _require_int("group_size", self.group_size, minimum=1)
+        _require_int("shard_index", self.shard_index, minimum=0)
+        _require_int("first_flat_index", self.first_flat_index, minimum=0)
+        if type(self.items) is not tuple or not self.items:
+            raise RolloutRouteTraceError("route shard items must be a non-empty tuple")
+        if len(self.items) > _MAX_ITEMS_PER_SHARD:
+            raise RolloutRouteTraceError("route shard item count exceeds the limit")
+        if any(not isinstance(item, RolloutRouteTraceItemV0) for item in self.items):
+            raise RolloutRouteTraceError(
+                "route shard contains an invalid route trace item"
+            )
+        if self.first_flat_index + len(self.items) > self.batch_size * self.group_size:
+            raise RolloutRouteTraceError("route shard range exceeds its rollout grid")
+
+    @property
+    def payload_nbytes(self) -> int:
+        return sum(len(item.payload) for item in self.items)
+
+
+def _item_header(item: RolloutRouteTraceItemV0) -> dict[str, Any]:
+    return {
+        "artifact_digest": item.artifact_digest,
+        "payload_nbytes": len(item.payload),
+        "sample_id": item.token_layout.sample_id,
+    }
+
+
+def _shard_header(shard: RolloutRouteTraceShardV0) -> dict[str, Any]:
+    return {
+        "batch_artifact_digest": shard.batch_artifact_digest,
+        "batch_size": shard.batch_size,
+        "first_flat_index": shard.first_flat_index,
+        "group_size": shard.group_size,
+        "items": [_item_header(item) for item in shard.items],
+        "schema_version": shard.schema_version,
+        "shard_index": shard.shard_index,
+    }
+
+
+class RolloutRouteTraceShardCodecV0:
+    """Length-prefixed, non-executable codec for one route-trace shard."""
+
+    @staticmethod
+    def dumps(shard: RolloutRouteTraceShardV0) -> bytes:
+        if not isinstance(shard, RolloutRouteTraceShardV0):
+            raise RolloutRouteTraceError("shard must be RolloutRouteTraceShardV0")
+        header = _canonical_json_bytes(_shard_header(shard))
+        if len(header) > _MAX_HEADER_BYTES:
+            raise RolloutRouteTraceError("route shard header exceeds the size limit")
+        return b"".join(
+            (
+                _FRAME_PREFIX.pack(_FRAME_MAGIC, len(header)),
+                header,
+                *(item.payload for item in shard.items),
+            )
+        )
+
+    @staticmethod
+    def loads(
+        data: bytes | bytearray | memoryview,
+        *,
+        max_shard_bytes: int = DEFAULT_ROUTE_TRACE_SHARD_BYTES,
+        max_item_bytes: int = DEFAULT_ROUTE_TRACE_SHARD_BYTES,
+        max_items: int = DEFAULT_ROUTE_TRACE_SHARD_ITEMS,
+    ) -> RolloutRouteTraceShardV0:
+        _require_int("max_shard_bytes", max_shard_bytes, minimum=1)
+        _require_int("max_item_bytes", max_item_bytes, minimum=1)
+        _require_int(
+            "max_items",
+            max_items,
+            minimum=1,
+            maximum=_MAX_ITEMS_PER_SHARD,
+        )
+        if not isinstance(data, (bytes, bytearray, memoryview)):
+            raise RolloutRouteTraceError("encoded route shard must be bytes-like")
+        data = bytes(data)
+        if len(data) > max_shard_bytes:
+            raise RolloutRouteTraceError("encoded route shard exceeds the size limit")
+        if len(data) < _FRAME_PREFIX.size:
+            raise RolloutRouteTraceError("encoded route shard is truncated")
+        magic, header_nbytes = _FRAME_PREFIX.unpack_from(data)
+        if magic != _FRAME_MAGIC:
+            raise RolloutRouteTraceError("encoded route shard magic does not match")
+        if header_nbytes < 2 or header_nbytes > _MAX_HEADER_BYTES:
+            raise RolloutRouteTraceError("route shard header size is invalid")
+        body_offset = _FRAME_PREFIX.size + header_nbytes
+        if body_offset > len(data):
+            raise RolloutRouteTraceError("encoded route shard header is truncated")
+        header = _decode_json_object(
+            data[_FRAME_PREFIX.size : body_offset],
+            label="route shard header",
+        )
+        fields = {
+            "batch_artifact_digest",
+            "batch_size",
+            "first_flat_index",
+            "group_size",
+            "items",
+            "schema_version",
+            "shard_index",
+        }
+        header = _require_exact_keys(header, fields, "route shard header")
+        _require_int(
+            "schema_version",
+            header["schema_version"],
+            minimum=ROLLOUT_ROUTE_TRACE_SHARD_SCHEMA_VERSION,
+            maximum=ROLLOUT_ROUTE_TRACE_SHARD_SCHEMA_VERSION,
+        )
+        _require_digest("batch_artifact_digest", header["batch_artifact_digest"])
+        batch_size = _require_int("batch_size", header["batch_size"], minimum=1)
+        group_size = _require_int("group_size", header["group_size"], minimum=1)
+        shard_index = _require_int("shard_index", header["shard_index"], minimum=0)
+        first_flat_index = _require_int(
+            "first_flat_index", header["first_flat_index"], minimum=0
+        )
+        item_headers = header["items"]
+        if not isinstance(item_headers, list) or not item_headers:
+            raise RolloutRouteTraceError(
+                "route shard header items must be a non-empty list"
+            )
+        if len(item_headers) > max_items:
+            raise RolloutRouteTraceError("route shard item count exceeds the limit")
+        if first_flat_index + len(item_headers) > batch_size * group_size:
+            raise RolloutRouteTraceError("route shard range exceeds its rollout grid")
+
+        item_fields = {"artifact_digest", "payload_nbytes", "sample_id"}
+        cursor = body_offset
+        items = []
+        for index, raw_item_header in enumerate(item_headers):
+            item_header = _require_exact_keys(
+                raw_item_header,
+                item_fields,
+                f"route shard item header {index}",
+            )
+            artifact_digest = _require_digest(
+                f"route shard item {index} artifact_digest",
+                item_header["artifact_digest"],
+            )
+            payload_nbytes = _require_int(
+                f"route shard item {index} payload_nbytes",
+                item_header["payload_nbytes"],
+                minimum=1,
+                maximum=max_item_bytes,
+            )
+            sample_id = _require_text(
+                f"route shard item {index} sample_id", item_header["sample_id"]
+            )
+            end = cursor + payload_nbytes
+            if end > len(data):
+                raise RolloutRouteTraceError("route shard item payload is truncated")
+            payload = data[cursor:end]
+            cursor = end
+            if _sha256(payload) != artifact_digest:
+                raise RolloutRouteTraceError(
+                    "route shard item payload digest does not match"
+                )
+            item = RolloutRouteTraceItemV0.from_payload(
+                payload,
+                max_serialized_bytes=max_item_bytes,
+            )
+            if item.token_layout.sample_id != sample_id:
+                raise RolloutRouteTraceError(
+                    "route shard item sample ID does not match its payload"
+                )
+            items.append(item)
+        if cursor != len(data):
+            raise RolloutRouteTraceError("encoded route shard has trailing bytes")
+        return RolloutRouteTraceShardV0(
+            batch_artifact_digest=header["batch_artifact_digest"],
+            batch_size=batch_size,
+            group_size=group_size,
+            shard_index=shard_index,
+            first_flat_index=first_flat_index,
+            items=tuple(items),
+        )
+
+
+@dataclass(frozen=True)
+class RolloutRouteTraceShardManifestV0:
+    """Small manifest needed to verify shards independently and reassemble."""
+
+    batch_artifact_digest: str
+    rollout_id: str
+    policy_version: int
+    prompt_batch_digest: str
+    response_batch_digest: str
+    behavior_logprobs_digest: str
+    batch_size: int
+    group_size: int
+    total_payload_nbytes: int
+    shards: tuple[RolloutRouteTraceShardDescriptorV0, ...]
+    batch_schema_version: int = ROLLOUT_ROUTE_TRACE_SCHEMA_VERSION
+    schema_version: int = ROLLOUT_ROUTE_TRACE_SHARD_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        _require_int(
+            "schema_version",
+            self.schema_version,
+            minimum=ROLLOUT_ROUTE_TRACE_SHARD_SCHEMA_VERSION,
+            maximum=ROLLOUT_ROUTE_TRACE_SHARD_SCHEMA_VERSION,
+        )
+        _require_int(
+            "batch_schema_version",
+            self.batch_schema_version,
+            minimum=ROLLOUT_ROUTE_TRACE_SCHEMA_VERSION,
+            maximum=ROLLOUT_ROUTE_TRACE_SCHEMA_VERSION,
+        )
+        _require_digest("batch_artifact_digest", self.batch_artifact_digest)
+        _require_text("rollout_id", self.rollout_id)
+        _require_int("policy_version", self.policy_version, minimum=0)
+        _require_digest("prompt_batch_digest", self.prompt_batch_digest)
+        _require_digest("response_batch_digest", self.response_batch_digest)
+        _require_digest("behavior_logprobs_digest", self.behavior_logprobs_digest)
+        _require_int("batch_size", self.batch_size, minimum=1)
+        _require_int("group_size", self.group_size, minimum=1)
+        _require_int("total_payload_nbytes", self.total_payload_nbytes, minimum=1)
+        if type(self.shards) is not tuple or not self.shards:
+            raise RolloutRouteTraceError(
+                "route shard descriptors must be a non-empty tuple"
+            )
+        if len(self.shards) > _MAX_SHARD_COUNT:
+            raise RolloutRouteTraceError("route shard count exceeds the limit")
+
+        next_flat_index = 0
+        payload_nbytes = 0
+        for shard_index, descriptor in enumerate(self.shards):
+            if not isinstance(descriptor, RolloutRouteTraceShardDescriptorV0):
+                raise RolloutRouteTraceError(
+                    "route shard manifest contains an invalid descriptor"
+                )
+            if descriptor.shard_index != shard_index:
+                raise RolloutRouteTraceError(
+                    "route shard descriptor indices must be canonical and contiguous"
+                )
+            if descriptor.first_flat_index != next_flat_index:
+                raise RolloutRouteTraceError(
+                    "route shard item ranges must be canonical and contiguous"
+                )
+            next_flat_index += descriptor.item_count
+            payload_nbytes += descriptor.payload_nbytes
+        if next_flat_index != self.batch_size * self.group_size:
+            raise RolloutRouteTraceError(
+                "route shard ranges do not exactly cover the rollout grid"
+            )
+        if payload_nbytes != self.total_payload_nbytes:
+            raise RolloutRouteTraceError(
+                "route shard payload sizes do not match the manifest total"
+            )
+
+    @property
+    def artifact_digest(self) -> str:
+        return canonical_json_digest(self.to_dict())
+
+    @property
+    def encoded_nbytes(self) -> int:
+        return sum(descriptor.encoded_nbytes for descriptor in self.shards)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "batch_artifact_digest": self.batch_artifact_digest,
+            "batch_schema_version": self.batch_schema_version,
+            "batch_size": self.batch_size,
+            "behavior_logprobs_digest": self.behavior_logprobs_digest,
+            "group_size": self.group_size,
+            "policy_version": self.policy_version,
+            "prompt_batch_digest": self.prompt_batch_digest,
+            "response_batch_digest": self.response_batch_digest,
+            "rollout_id": self.rollout_id,
+            "schema_version": self.schema_version,
+            "shards": [descriptor.to_dict() for descriptor in self.shards],
+            "total_payload_nbytes": self.total_payload_nbytes,
+        }
+
+    def dumps(self) -> bytes:
+        payload = _canonical_json_bytes(self.to_dict())
+        if len(payload) > _MAX_MANIFEST_BYTES:
+            raise RolloutRouteTraceError("route shard manifest exceeds the size limit")
+        return payload
+
+    @classmethod
+    def loads(
+        cls,
+        data: bytes | bytearray | memoryview,
+        *,
+        max_manifest_bytes: int = _MAX_MANIFEST_BYTES,
+        max_shards: int = _MAX_SHARD_COUNT,
+        max_shard_bytes: int = DEFAULT_ROUTE_TRACE_SHARD_BYTES,
+        max_transport_bytes: int = DEFAULT_ROUTE_TRACE_TRANSPORT_BYTES,
+    ) -> RolloutRouteTraceShardManifestV0:
+        _require_int("max_manifest_bytes", max_manifest_bytes, minimum=1)
+        _require_int(
+            "max_shards",
+            max_shards,
+            minimum=1,
+            maximum=_MAX_SHARD_COUNT,
+        )
+        _require_int("max_shard_bytes", max_shard_bytes, minimum=1)
+        _require_int("max_transport_bytes", max_transport_bytes, minimum=1)
+        if not isinstance(data, (bytes, bytearray, memoryview)):
+            raise RolloutRouteTraceError("route shard manifest must be bytes-like")
+        data = bytes(data)
+        if len(data) > max_manifest_bytes:
+            raise RolloutRouteTraceError("route shard manifest exceeds the size limit")
+        value = _decode_json_object(data, label="route shard manifest")
+        fields = {
+            "batch_artifact_digest",
+            "batch_schema_version",
+            "batch_size",
+            "behavior_logprobs_digest",
+            "group_size",
+            "policy_version",
+            "prompt_batch_digest",
+            "response_batch_digest",
+            "rollout_id",
+            "schema_version",
+            "shards",
+            "total_payload_nbytes",
+        }
+        value = _require_exact_keys(value, fields, "route shard manifest")
+        raw_descriptors = value["shards"]
+        if not isinstance(raw_descriptors, list) or not raw_descriptors:
+            raise RolloutRouteTraceError(
+                "route shard manifest descriptors must be a non-empty list"
+            )
+        if len(raw_descriptors) > max_shards:
+            raise RolloutRouteTraceError("route shard count exceeds the limit")
+        kwargs = {name: value[name] for name in fields - {"shards"}}
+        manifest = cls(
+            **kwargs,
+            shards=tuple(
+                RolloutRouteTraceShardDescriptorV0.from_dict(descriptor)
+                for descriptor in raw_descriptors
+            ),
+        )
+        if any(
+            descriptor.encoded_nbytes > max_shard_bytes
+            for descriptor in manifest.shards
+        ):
+            raise RolloutRouteTraceError("declared route shard exceeds max_shard_bytes")
+        if len(data) + manifest.encoded_nbytes > max_transport_bytes:
+            raise RolloutRouteTraceError(
+                "declared route transport exceeds max_transport_bytes"
+            )
+        return manifest
+
+    def shard_indices_for_rank(self, rank: int, world_size: int) -> tuple[int, ...]:
+        """Assign canonical shard indices round-robin for any positive world size."""
+        _require_int("world_size", world_size, minimum=1)
+        _require_int("rank", rank, minimum=0)
+        if rank >= world_size:
+            raise RolloutRouteTraceError("rank must be smaller than world_size")
+        return tuple(range(rank, len(self.shards), world_size))
+
+    def verify_shard(
+        self,
+        shard_index: int,
+        payload: bytes | bytearray | memoryview,
+    ) -> RolloutRouteTraceShardV0:
+        _require_int("shard_index", shard_index, minimum=0)
+        if shard_index >= len(self.shards):
+            raise RolloutRouteTraceError("shard_index is outside the manifest")
+        descriptor = self.shards[shard_index]
+        if not isinstance(payload, (bytes, bytearray, memoryview)):
+            raise RolloutRouteTraceError("encoded route shard must be bytes-like")
+        payload = bytes(payload)
+        if len(payload) != descriptor.encoded_nbytes:
+            raise RolloutRouteTraceError(
+                "encoded route shard size does not match its descriptor"
+            )
+        if _sha256(payload) != descriptor.encoded_sha256:
+            raise RolloutRouteTraceError(
+                "encoded route shard digest does not match its descriptor"
+            )
+        shard = RolloutRouteTraceShardCodecV0.loads(
+            payload,
+            max_shard_bytes=descriptor.encoded_nbytes,
+            max_item_bytes=descriptor.payload_nbytes,
+            max_items=descriptor.item_count,
+        )
+        if shard.batch_artifact_digest != self.batch_artifact_digest:
+            raise RolloutRouteTraceError("route shard belongs to a different batch")
+        if (shard.batch_size, shard.group_size) != (
+            self.batch_size,
+            self.group_size,
+        ):
+            raise RolloutRouteTraceError("route shard rollout grid does not match")
+        if shard.shard_index != descriptor.shard_index:
+            raise RolloutRouteTraceError("route shard index does not match")
+        if shard.first_flat_index != descriptor.first_flat_index:
+            raise RolloutRouteTraceError("route shard range does not match")
+        if len(shard.items) != descriptor.item_count:
+            raise RolloutRouteTraceError("route shard item count does not match")
+        if shard.payload_nbytes != descriptor.payload_nbytes:
+            raise RolloutRouteTraceError("route shard payload size does not match")
+        return shard
+
+    def assemble(
+        self,
+        shard_payloads: Sequence[bytes | bytearray | memoryview],
+    ) -> RolloutRouteTraceBatchV0:
+        """Reconstruct the original batch only from the exact complete shard set."""
+        if isinstance(
+            shard_payloads, (str, bytes, bytearray, memoryview)
+        ) or not isinstance(shard_payloads, Sequence):
+            raise RolloutRouteTraceError("shard_payloads must be an ordered sequence")
+        if len(shard_payloads) != len(self.shards):
+            raise RolloutRouteTraceError(
+                "shard payload count does not match the manifest"
+            )
+        flat_items = []
+        for shard_index, payload in enumerate(shard_payloads):
+            flat_items.extend(self.verify_shard(shard_index, payload).items)
+        rows = tuple(
+            tuple(flat_items[start : start + self.group_size])
+            for start in range(0, len(flat_items), self.group_size)
+        )
+        batch = RolloutRouteTraceBatchV0(
+            rollout_id=self.rollout_id,
+            policy_version=self.policy_version,
+            prompt_batch_digest=self.prompt_batch_digest,
+            response_batch_digest=self.response_batch_digest,
+            behavior_logprobs_digest=self.behavior_logprobs_digest,
+            items=rows,
+            schema_version=self.batch_schema_version,
+        )
+        if batch.payload_nbytes != self.total_payload_nbytes:
+            raise RolloutRouteTraceError(
+                "reassembled route trace payload size does not match"
+            )
+        if batch.artifact_digest != self.batch_artifact_digest:
+            raise RolloutRouteTraceError(
+                "reassembled route trace batch digest does not match"
+            )
+        return batch
+
+
+def _encoded_nbytes(
+    *,
+    batch_artifact_digest: str,
+    batch_size: int,
+    group_size: int,
+    shard_index: int,
+    first_flat_index: int,
+    items: Sequence[RolloutRouteTraceItemV0],
+) -> int:
+    empty = RolloutRouteTraceShardV0(
+        batch_artifact_digest=batch_artifact_digest,
+        batch_size=batch_size,
+        group_size=group_size,
+        shard_index=shard_index,
+        first_flat_index=first_flat_index,
+        items=(items[0],),
+    )
+    base_header = _shard_header(empty)
+    base_header["items"] = []
+    base_nbytes = len(_canonical_json_bytes(base_header))
+    item_header_nbytes = sum(
+        len(_canonical_json_bytes(_item_header(item))) for item in items
+    )
+    separators = max(0, len(items) - 1)
+    header_nbytes = base_nbytes + item_header_nbytes + separators
+    return _FRAME_PREFIX.size + header_nbytes + sum(len(item.payload) for item in items)
+
+
+@dataclass(frozen=True)
+class RolloutRouteTraceTransportV0:
+    """Sender-side manifest and immutable shard byte frames."""
+
+    manifest: RolloutRouteTraceShardManifestV0
+    shard_payloads: tuple[bytes, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.manifest, RolloutRouteTraceShardManifestV0):
+            raise RolloutRouteTraceError(
+                "manifest must be RolloutRouteTraceShardManifestV0"
+            )
+        if type(self.shard_payloads) is not tuple:
+            raise RolloutRouteTraceError("shard_payloads must be an immutable tuple")
+        if len(self.shard_payloads) != len(self.manifest.shards):
+            raise RolloutRouteTraceError(
+                "shard payload count does not match the manifest"
+            )
+        for descriptor, payload in zip(self.manifest.shards, self.shard_payloads):
+            if type(payload) is not bytes:
+                raise RolloutRouteTraceError(
+                    "encoded route shard payloads must be immutable bytes"
+                )
+            if len(payload) != descriptor.encoded_nbytes:
+                raise RolloutRouteTraceError(
+                    "encoded route shard size does not match its descriptor"
+                )
+            if _sha256(payload) != descriptor.encoded_sha256:
+                raise RolloutRouteTraceError(
+                    "encoded route shard digest does not match its descriptor"
+                )
+
+    @classmethod
+    def from_batch(
+        cls,
+        batch: RolloutRouteTraceBatchV0,
+        *,
+        max_shard_bytes: int = DEFAULT_ROUTE_TRACE_SHARD_BYTES,
+        max_items_per_shard: int = DEFAULT_ROUTE_TRACE_SHARD_ITEMS,
+    ) -> RolloutRouteTraceTransportV0:
+        """Partition a bound rollout batch into deterministic bounded shards."""
+        if not isinstance(batch, RolloutRouteTraceBatchV0):
+            raise RolloutRouteTraceError("batch must be RolloutRouteTraceBatchV0")
+        _require_int("max_shard_bytes", max_shard_bytes, minimum=1)
+        _require_int(
+            "max_items_per_shard",
+            max_items_per_shard,
+            minimum=1,
+            maximum=_MAX_ITEMS_PER_SHARD,
+        )
+        flat_items = tuple(item for row in batch.items for item in row)
+        batch_artifact_digest = batch.artifact_digest
+        chunks: list[tuple[int, tuple[RolloutRouteTraceItemV0, ...]]] = []
+        current: list[RolloutRouteTraceItemV0] = []
+        first_flat_index = 0
+        shard_index = 0
+        for flat_index, item in enumerate(flat_items):
+            candidate = (*current, item)
+            candidate_nbytes = _encoded_nbytes(
+                batch_artifact_digest=batch_artifact_digest,
+                batch_size=batch.batch_size,
+                group_size=batch.group_size,
+                shard_index=shard_index,
+                first_flat_index=first_flat_index,
+                items=candidate,
+            )
+            exceeds = (
+                len(candidate) > max_items_per_shard
+                or candidate_nbytes > max_shard_bytes
+            )
+            if exceeds and current:
+                chunks.append((first_flat_index, tuple(current)))
+                shard_index += 1
+                first_flat_index = flat_index
+                current = [item]
+                single_nbytes = _encoded_nbytes(
+                    batch_artifact_digest=batch_artifact_digest,
+                    batch_size=batch.batch_size,
+                    group_size=batch.group_size,
+                    shard_index=shard_index,
+                    first_flat_index=first_flat_index,
+                    items=current,
+                )
+                if single_nbytes > max_shard_bytes:
+                    raise RolloutRouteTraceError(
+                        "one route trace item exceeds max_shard_bytes"
+                    )
+            elif exceeds:
+                raise RolloutRouteTraceError(
+                    "one route trace item exceeds max_shard_bytes"
+                )
+            else:
+                current.append(item)
+        if current:
+            chunks.append((first_flat_index, tuple(current)))
+        if len(chunks) > _MAX_SHARD_COUNT:
+            raise RolloutRouteTraceError("route shard count exceeds the limit")
+
+        shard_payloads = []
+        descriptors = []
+        for shard_index, (first_flat_index, items) in enumerate(chunks):
+            shard = RolloutRouteTraceShardV0(
+                batch_artifact_digest=batch_artifact_digest,
+                batch_size=batch.batch_size,
+                group_size=batch.group_size,
+                shard_index=shard_index,
+                first_flat_index=first_flat_index,
+                items=items,
+            )
+            payload = RolloutRouteTraceShardCodecV0.dumps(shard)
+            if len(payload) > max_shard_bytes:
+                raise RolloutRouteTraceError(
+                    "encoded route shard exceeds max_shard_bytes"
+                )
+            shard_payloads.append(payload)
+            descriptors.append(
+                RolloutRouteTraceShardDescriptorV0(
+                    shard_index=shard_index,
+                    first_flat_index=first_flat_index,
+                    item_count=len(items),
+                    payload_nbytes=shard.payload_nbytes,
+                    encoded_nbytes=len(payload),
+                    encoded_sha256=_sha256(payload),
+                )
+            )
+        manifest = RolloutRouteTraceShardManifestV0(
+            batch_artifact_digest=batch_artifact_digest,
+            rollout_id=batch.rollout_id,
+            policy_version=batch.policy_version,
+            prompt_batch_digest=batch.prompt_batch_digest,
+            response_batch_digest=batch.response_batch_digest,
+            behavior_logprobs_digest=batch.behavior_logprobs_digest,
+            batch_size=batch.batch_size,
+            group_size=batch.group_size,
+            total_payload_nbytes=batch.payload_nbytes,
+            shards=tuple(descriptors),
+            batch_schema_version=batch.schema_version,
+        )
+        return cls(manifest=manifest, shard_payloads=tuple(shard_payloads))
+
+    @property
+    def transport_nbytes(self) -> int:
+        return len(self.manifest.dumps()) + self.manifest.encoded_nbytes
+
+    def payloads_for_rank(
+        self,
+        rank: int,
+        world_size: int,
+    ) -> tuple[tuple[int, bytes], ...]:
+        """Return this rank's deterministic shard subset without decoding it."""
+        indices = self.manifest.shard_indices_for_rank(rank, world_size)
+        return tuple((index, self.shard_payloads[index]) for index in indices)
+
+    def assemble(self) -> RolloutRouteTraceBatchV0:
+        return self.manifest.assemble(self.shard_payloads)

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -6,6 +6,8 @@
 - [Module Overview](#module-overview) — Component inventory per module
 - [Design Patterns](#design-patterns) — 16 documented patterns with classes
 - [Core Relationships](#core-relationships) — 11 key inter-component relationships
+- [MoE route trace contract](route_trace.md) — versioned behavior identity,
+  safe serialization, and diagnostics
 
 ## Class Diagram
 

--- a/docs/developer/route_trace.md
+++ b/docs/developer/route_trace.md
@@ -1,0 +1,178 @@
+# Versioned MoE route trace contract
+
+`astrai.moe` defines `RouteTraceV0`, a compact behavior artifact for one
+contiguous token span. The contract is intentionally separate from model
+capture, rollout transport, expert dispatch, replay, and GRPO admission. Merely
+importing or constructing these objects does not change a forward pass or the
+training objective.
+
+## Identity and semantics
+
+A trace is interpretable only when all four components agree:
+
+- `RouteIdentityV0` binds `policy_version`, model/checkpoint revisions, router
+  and load-controller versions, and the router schema digest.
+- `RouterSchemaV0` binds layer/expert/top-k geometry, EP world size, score and
+  selected-weight semantics, expert and token ordering, padding, backend/kernel
+  semantics, and a content-addressed parallel layout.
+- `RouteTokenLayoutV0` identifies one sample, its full sequence and prompt
+  boundaries, and the captured contiguous prompt/response span.
+- `RouteTraceLevel` states whether the payload carries IDs only or IDs plus
+  selected weights and top-k margin.
+
+`RouterSchemaV0.fingerprint` is canonical JSON SHA-256. A trace whose identity
+does not contain that exact digest is rejected at construction and decode time.
+Consumers call `require_compatible_route_trace(...)` with their expected
+identity, schema, token span, and minimum payload level. Every field is compared
+exactly; there is no silent fallback for an unknown version or semantic field.
+
+## Tensor layout
+
+One trace represents one sample span:
+
+```text
+topk_ids          [tokens, moe_layers, top_k]
+selected_weights  [tokens, moe_layers, top_k]  optional
+topk_margin       [tokens, moe_layers]         optional
+valid_mask        [tokens]                     optional
+```
+
+IDs use the narrowest unsigned storage capable of representing all experts:
+
+```text
+num_experts <= 256    -> uint8
+num_experts <= 65536  -> uint16
+otherwise             -> uint32
+```
+
+Use `pack_route_ids(...)` to range-check and compact an integer tensor. Valid
+top-k rows must contain unique in-range experts. Invalid/padded rows must be
+canonical zeros, making their serialized bytes deterministic and preventing
+uninitialized padding from becoming part of behavior identity.
+
+`IDS_WEIGHTS_MARGIN` requires both optional floating tensors. Selected weights
+must be detached, finite, non-negative, and conform to the declared
+`full-softmax-selected` or `selected-renormalized` semantics. Margins are the
+non-negative top-k versus top-(k+1) score gap. The helper
+`compute_topk_margin(...)` computes this diagnostic after an explicit FP32
+conversion, including for BF16 near ties.
+
+## Safe serialization
+
+`RouteTraceCodecV0.dumps()` produces bytes suitable for an async rollout
+buffer. It does not use pickle. The outer container is safetensors; a strict
+canonical JSON manifest describes each logical tensor's dtype, shape, byte
+count, and SHA-256. Unsigned types unsupported by older safetensors releases
+are encoded as checked raw `uint8` buffers. The v0 wire format records and
+requires little-endian tensor bytes rather than silently interpreting a payload
+with the host's native byte order.
+
+`RouteTraceCodecV0.loads()` returns detached CPU tensors and rejects:
+
+- unknown/missing manifest or tensor fields;
+- unknown codec or schema versions;
+- malformed identity, schema, or token boundaries;
+- tensor-name, dtype, shape, byte-count, or checksum mismatch;
+- unsupported byte order, sparse/meta tensors, or non-canonical negative zero;
+- payloads above the caller's byte budget;
+- any trace invariant that construction would reject.
+
+The codec digest is available as `trace.artifact_digest`. Artifact storage or
+transport should retain that digest together with the policy/checkpoint
+identity, but those integrations belong in follow-up changes.
+
+## Codec microbenchmark
+
+The repository includes a deterministic serialization-only benchmark:
+
+```bash
+python scripts/benchmark_route_trace_codec.py \
+  --tokens 8192 --layers 40 --top-k 22 --num-experts 512 \
+  --level ids --device cpu --warmups 5 --repeats 50
+```
+
+The JSON output separates logical tensor bytes, wire bytes, and an int64-ID
+baseline, and reports serialize/deserialize latency. Construction happens
+outside the timed region. The benchmark does not measure model capture, D2H
+overlap, rollout transport, replay, training throughput, or end-to-end memory.
+
+## Diagnostics only
+
+`compare_route_traces(...)` requires exact router semantics, token layout,
+validity mask, and device while allowing behavior/current versions to differ.
+It reports:
+
+- ordered top-k equality;
+- unordered expert-set overlap and flip fraction;
+- sparse selected-weight L1 shift when both traces carry weights;
+- behavior margin mean and fragile-position fraction when margin is available.
+
+Missing optional data produces `None`, never a fabricated zero. Empty valid
+populations, mismatched layouts, and requested margin diagnostics without
+margins fail closed. These scalars are observations only; this module never
+rejects, downweights, or replays a rollout.
+
+## Example
+
+```python
+import torch
+
+from astrai.moe import (
+    PaddingLayout,
+    RouteIdentityV0,
+    RouterSchemaV0,
+    RouteTokenLayoutV0,
+    RouteTraceCodecV0,
+    RouteTraceLevel,
+    RouteTraceV0,
+    SelectedWeightSemantics,
+    TokenSpanKind,
+    canonical_json_digest,
+    pack_route_ids,
+)
+
+schema = RouterSchemaV0(
+    num_moe_layers=2,
+    num_experts=64,
+    top_k=2,
+    expert_parallel_world_size=1,
+    score_function="softmax-fp32-before-topk",
+    score_dtype="float32",
+    expert_id_ordering="score-descending-stable-index",
+    selected_weight_semantics=SelectedWeightSemantics.SELECTED_RENORMALIZED,
+    token_ordering="single-sequence-token-major",
+    padding_layout=PaddingLayout.NONE,
+    backend="astrai-torch",
+    kernel_semantics_version="torch-topk-v1",
+    parallel_layout_hash=canonical_json_digest({"placement": "all-local"}),
+)
+identity = RouteIdentityV0(
+    policy_version=12,
+    model_revision="model-12",
+    router_state_version=12,
+    checkpoint_revision="checkpoint-12",
+    router_schema_hash=schema.fingerprint,
+)
+layout = RouteTokenLayoutV0(
+    sample_id="opaque-sample-id",
+    sequence_token_count=2,
+    prompt_token_count=0,
+    token_offset=0,
+    token_count=2,
+    span_kind=TokenSpanKind.FULL_SEQUENCE,
+)
+trace = RouteTraceV0(
+    identity=identity,
+    router_schema=schema,
+    token_layout=layout,
+    level=RouteTraceLevel.IDS,
+    topk_ids=pack_route_ids(torch.tensor([[[0, 1]], [[2, 3]]]), 64),
+)
+wire_bytes = RouteTraceCodecV0.dumps(trace)
+restored = RouteTraceCodecV0.loads(wire_bytes)
+```
+
+Before adding capture or replay, a follow-up must define how model revision,
+checkpoint revision, router-state version, kernel semantics, token boundaries,
+and parallel-layout digest are sourced atomically. That integration must remain
+opt-in and preserve the current model path when disabled.

--- a/docs/developer/route_trace.md
+++ b/docs/developer/route_trace.md
@@ -223,3 +223,37 @@ verification. Validation hashes only the comparatively small rollout token,
 mask, and behavior-logprob tensors and checks cached headers; it does not
 decode route payloads. The benchmark excludes generation, model capture,
 transport, replay, scoring, and training.
+
+## Sharded transport frames
+
+`astrai.trainer.route_trace_transport.RolloutRouteTraceTransportV0` converts an
+already bound rollout batch into deterministic, row-major byte shards. The
+caller sets both an encoded-byte limit and an item-count limit; a single trace
+that cannot fit fails loudly instead of silently exceeding the configured
+bound. The small JSON manifest records the original batch digest and exact
+contiguous range, encoded size, payload size, and SHA-256 digest of every
+shard.
+
+Each shard is a non-executable length-prefixed frame containing canonical JSON
+metadata and the existing safe RouteTrace payloads. A receiver can validate
+only its assigned shard against the manifest. Decoders reject non-canonical
+JSON metadata. Complete reconstruction rejects missing, reordered, corrupt,
+cross-batch, or trailing data and must reproduce the original
+`RolloutRouteTraceBatchV0.artifact_digest`. Rank assignment is a generic
+deterministic round-robin over shards; CPU Gloo tests cover world sizes two and
+four. The codec does not choose a network or mutate rollout or training
+behavior.
+
+Measure CPU framing, verification, byte overhead, and reconstruction with:
+
+```bash
+python scripts/benchmark_rollout_route_transport.py \
+  --batch-size 8 --group-size 8 --prompt-tokens 512 \
+  --response-tokens 1024 --layers 40 --top-k 22 --num-experts 512 \
+  --level ids --max-shard-bytes 16777216 --max-items-per-shard 8 \
+  --warmups 2 --repeats 5
+```
+
+The result also reports the encoded-byte distribution for two and four
+consumer ranks. It deliberately excludes actual network throughput, model
+capture, generation, replay, scoring, and optimizer work.

--- a/docs/developer/route_trace.md
+++ b/docs/developer/route_trace.md
@@ -176,3 +176,50 @@ Before adding capture or replay, a follow-up must define how model revision,
 checkpoint revision, router-state version, kernel semantics, token boundaries,
 and parallel-layout digest are sourced atomically. That integration must remain
 opt-in and preserve the current model path when disabled.
+
+## Online rollout binding
+
+`astrai.trainer.route_trace.RolloutRouteTraceBatchV0` binds a rectangular
+`[batch, group]` grid of response traces to the exact rollout policy version,
+prompt tokens/mask, response tokens/mask, and behavior logprobs. `bind(...)`
+freezes each trace as immutable codec bytes and retains a verified lightweight
+header, so later cache checks do not decode the large route tensors again. The
+batch digest also binds ordered per-response artifact digests and a
+caller-provided rollout ID.
+
+The binding uses one canonical padded layout:
+
+- prompts are left padded with zero token IDs;
+- responses and route rows are right padded with zeros;
+- every response trace spans the complete padded response width;
+- `token_offset` and `prompt_token_count` equal that sample's valid prompt
+  length;
+- the trace validity mask exactly equals the corresponding response mask;
+- each sample ID is derived from the rollout ID and its exact batch/group
+  coordinate, preventing same-length responses from being silently swapped;
+- all traces in the batch share one behavior identity, router schema, payload
+  level, and policy version, and carry unique sample IDs.
+
+`RawRollout.route_trace_batch` and `RolloutResult.route_trace_batch` default to
+`None`, preserving the existing generation path. When populated, the runner
+validates the binding before scoring, after scoring, before cache publication,
+and on every cache reuse. Token mutation, a swapped trace, an overlaid policy
+version, or a boundary/mask mismatch fails closed. This layer does not capture
+routes, replay experts, or use route metrics to change sample admission.
+
+Measure immutable binding and cache-validation cost separately from model
+capture with:
+
+```bash
+python scripts/benchmark_rollout_route_binding.py \
+  --batch-size 2 --group-size 2 --prompt-tokens 512 \
+  --response-tokens 1024 --layers 40 --top-k 22 --num-experts 512 \
+  --level ids --device cpu --warmups 5 \
+  --bind-repeats 5 --validate-repeats 50
+```
+
+The reported bind time includes per-trace serialization and immutable-header
+verification. Validation hashes only the comparatively small rollout token,
+mask, and behavior-logprob tensors and checks cached headers; it does not
+decode route payloads. The benchmark excludes generation, model capture,
+transport, replay, scoring, and training.

--- a/scripts/benchmark_rollout_route_binding.py
+++ b/scripts/benchmark_rollout_route_binding.py
@@ -1,0 +1,297 @@
+"""Measure immutable rollout-to-RouteTraceV0 binding and validation cost.
+
+This microbenchmark starts from already materialized synthetic route tensors.
+It does not measure model capture, generation, transport, replay, reward
+scoring, optimizer work, or end-to-end training throughput.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import time
+from dataclasses import replace
+from pathlib import Path
+
+import torch
+
+from astrai.moe import RouteTraceLevel, RouteTraceV0, TokenSpanKind
+from astrai.trainer.route_trace import (
+    RolloutRouteTraceBatchV0,
+    rollout_route_sample_id,
+)
+from scripts.benchmark_route_trace_codec import build_trace
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    ordered = sorted(values)
+    return ordered[max(0, math.ceil(percentile * len(ordered)) - 1)]
+
+
+def _synchronize(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def build_rollout_inputs(
+    *,
+    batch_size: int,
+    group_size: int,
+    prompt_tokens: int,
+    response_tokens: int,
+    layers: int,
+    top_k: int,
+    num_experts: int,
+    level: RouteTraceLevel,
+    device: torch.device,
+    rollout_id: str = "rollout-route-binding-benchmark",
+) -> tuple[dict[str, torch.Tensor], list[list[RouteTraceV0]]]:
+    """Build deterministic, fully valid tokens and a B-by-G trace grid."""
+    dimensions = (
+        batch_size,
+        group_size,
+        prompt_tokens,
+        response_tokens,
+        layers,
+        top_k,
+        num_experts,
+    )
+    if min(dimensions) < 1 or top_k > num_experts:
+        raise ValueError("dimensions must be positive and top_k <= num_experts")
+
+    prompts = (
+        torch.arange(1, prompt_tokens + 1, dtype=torch.long, device=device)
+        .unsqueeze(0)
+        .expand(batch_size, -1)
+        .clone()
+    )
+    responses = (
+        torch.arange(1, response_tokens + 1, dtype=torch.long, device=device)
+        .reshape(1, 1, -1)
+        .expand(batch_size, group_size, -1)
+        .clone()
+    )
+    response_offsets = torch.arange(
+        batch_size * group_size, dtype=torch.long, device=device
+    ).reshape(batch_size, group_size, 1)
+    responses.add_(response_offsets * response_tokens)
+    prompt_mask = torch.ones_like(prompts, dtype=torch.bool)
+    response_mask = torch.ones_like(responses, dtype=torch.bool)
+    logprobs_old = torch.full_like(responses, -0.5, dtype=torch.float32)
+
+    base = build_trace(
+        tokens=response_tokens,
+        layers=layers,
+        top_k=top_k,
+        num_experts=num_experts,
+        level=level,
+        device=device,
+    )
+    identity = replace(
+        base.identity,
+        policy_version=17,
+        model_revision="synthetic-model-17",
+        router_state_version=17,
+        checkpoint_revision="synthetic-checkpoint-17",
+    )
+    traces = []
+    for batch_index in range(batch_size):
+        row = []
+        for group_index in range(group_size):
+            row.append(
+                RouteTraceV0(
+                    identity=identity,
+                    router_schema=base.router_schema,
+                    token_layout=replace(
+                        base.token_layout,
+                        sample_id=rollout_route_sample_id(
+                            rollout_id, batch_index, group_index
+                        ),
+                        sequence_token_count=prompt_tokens + response_tokens,
+                        prompt_token_count=prompt_tokens,
+                        token_offset=prompt_tokens,
+                        span_kind=TokenSpanKind.RESPONSE,
+                    ),
+                    level=base.level,
+                    topk_ids=base.topk_ids,
+                    selected_weights=base.selected_weights,
+                    topk_margin=base.topk_margin,
+                )
+            )
+        traces.append(row)
+    return {
+        "prompts": prompts,
+        "prompt_mask": prompt_mask,
+        "responses": responses,
+        "response_mask": response_mask,
+        "logprobs_old": logprobs_old,
+    }, traces
+
+
+def run_benchmark(
+    *,
+    batch_size: int,
+    group_size: int,
+    prompt_tokens: int,
+    response_tokens: int,
+    layers: int,
+    top_k: int,
+    num_experts: int,
+    level: RouteTraceLevel,
+    device: torch.device,
+    warmups: int,
+    bind_repeats: int,
+    validate_repeats: int,
+) -> dict:
+    """Return byte accounting and bind/validation latency statistics."""
+    if warmups < 0 or min(bind_repeats, validate_repeats) < 1:
+        raise ValueError("warmups must be non-negative and repeats must be positive")
+    rollout_id = "rollout-route-binding-benchmark"
+    tensors, traces = build_rollout_inputs(
+        batch_size=batch_size,
+        group_size=group_size,
+        prompt_tokens=prompt_tokens,
+        response_tokens=response_tokens,
+        layers=layers,
+        top_k=top_k,
+        num_experts=num_experts,
+        level=level,
+        device=device,
+        rollout_id=rollout_id,
+    )
+
+    def bind() -> RolloutRouteTraceBatchV0:
+        return RolloutRouteTraceBatchV0.bind(
+            rollout_id=rollout_id,
+            policy_version=17,
+            traces=traces,
+            **tensors,
+        )
+
+    bound = bind()
+    for _ in range(warmups):
+        bound.validate_against(policy_version=17, **tensors)
+
+    bind_us = []
+    for _ in range(bind_repeats):
+        _synchronize(device)
+        started = time.perf_counter_ns()
+        candidate = bind()
+        _synchronize(device)
+        bind_us.append((time.perf_counter_ns() - started) / 1000)
+        if candidate.artifact_digest != bound.artifact_digest:
+            raise RuntimeError("rollout binding is not deterministic")
+
+    validate_us = []
+    for _ in range(validate_repeats):
+        _synchronize(device)
+        started = time.perf_counter_ns()
+        bound.validate_against(policy_version=17, **tensors)
+        _synchronize(device)
+        validate_us.append((time.perf_counter_ns() - started) / 1000)
+
+    manifest_bytes = len(
+        json.dumps(
+            bound.manifest(),
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    )
+    return {
+        "schema_version": 1,
+        "benchmark": "astrai-rollout-route-trace-binding-v0",
+        "scope": (
+            "binding/validation only; excludes capture, generation, transport, "
+            "replay, scoring, and training"
+        ),
+        "device": str(device),
+        "torch_version": torch.__version__,
+        "parameters": {
+            "batch_size": batch_size,
+            "group_size": group_size,
+            "prompt_tokens": prompt_tokens,
+            "response_tokens": response_tokens,
+            "layers": layers,
+            "top_k": top_k,
+            "num_experts": num_experts,
+            "level": level.value,
+            "warmups": warmups,
+            "bind_repeats": bind_repeats,
+            "validate_repeats": validate_repeats,
+        },
+        "bytes": {
+            "trace_payloads": bound.payload_nbytes,
+            "identity_manifest": manifest_bytes,
+            "trace_payload_per_response": bound.payload_nbytes
+            / (batch_size * group_size),
+        },
+        "latency_us": {
+            "bind_median": statistics.median(bind_us),
+            "bind_p95": _percentile(bind_us, 0.95),
+            "validate_median": statistics.median(validate_us),
+            "validate_p95": _percentile(validate_us, 0.95),
+        },
+        "artifact_digest": bound.artifact_digest,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--batch-size", type=_positive_int, default=2)
+    parser.add_argument("--group-size", type=_positive_int, default=2)
+    parser.add_argument("--prompt-tokens", type=_positive_int, default=512)
+    parser.add_argument("--response-tokens", type=_positive_int, default=1024)
+    parser.add_argument("--layers", type=_positive_int, default=40)
+    parser.add_argument("--top-k", type=_positive_int, default=22)
+    parser.add_argument("--num-experts", type=_positive_int, default=512)
+    parser.add_argument(
+        "--level",
+        choices=[level.value for level in RouteTraceLevel],
+        default=RouteTraceLevel.IDS.value,
+    )
+    parser.add_argument("--device", choices=("cpu", "cuda"), default="cpu")
+    parser.add_argument("--warmups", type=int, default=5)
+    parser.add_argument("--bind-repeats", type=_positive_int, default=5)
+    parser.add_argument("--validate-repeats", type=_positive_int, default=50)
+    parser.add_argument("--output-json", type=Path)
+    args = parser.parse_args()
+    if args.warmups < 0:
+        parser.error("--warmups must be non-negative")
+    if args.top_k > args.num_experts:
+        parser.error("--top-k must not exceed --num-experts")
+    if args.device == "cuda" and not torch.cuda.is_available():
+        parser.error("--device cuda requires an available CUDA device")
+
+    report = run_benchmark(
+        batch_size=args.batch_size,
+        group_size=args.group_size,
+        prompt_tokens=args.prompt_tokens,
+        response_tokens=args.response_tokens,
+        layers=args.layers,
+        top_k=args.top_k,
+        num_experts=args.num_experts,
+        level=RouteTraceLevel(args.level),
+        device=torch.device(args.device),
+        warmups=args.warmups,
+        bind_repeats=args.bind_repeats,
+        validate_repeats=args.validate_repeats,
+    )
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_rollout_route_transport.py
+++ b/scripts/benchmark_rollout_route_transport.py
@@ -1,0 +1,248 @@
+"""Measure bounded rollout RouteTrace shard framing and reconstruction.
+
+This starts from an already bound synthetic rollout route batch. It measures
+CPU byte framing, independent verification, and complete reconstruction. It
+does not measure a particular network, model capture, generation, replay,
+optimizer work, or end-to-end training throughput.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import time
+from pathlib import Path
+
+import torch
+
+from astrai.moe import RouteTraceLevel
+from astrai.trainer.route_trace import RolloutRouteTraceBatchV0
+from astrai.trainer.route_trace_transport import RolloutRouteTraceTransportV0
+from scripts.benchmark_rollout_route_binding import build_rollout_inputs
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    ordered = sorted(values)
+    return ordered[max(0, math.ceil(percentile * len(ordered)) - 1)]
+
+
+def _latency_summary(values: list[float]) -> dict[str, float]:
+    return {
+        "median": statistics.median(values),
+        "p95": _percentile(values, 0.95),
+    }
+
+
+def run_benchmark(
+    *,
+    batch_size: int,
+    group_size: int,
+    prompt_tokens: int,
+    response_tokens: int,
+    layers: int,
+    top_k: int,
+    num_experts: int,
+    level: RouteTraceLevel,
+    max_shard_bytes: int,
+    max_items_per_shard: int,
+    warmups: int,
+    repeats: int,
+) -> dict:
+    """Return deterministic byte accounting and CPU codec latency."""
+    dimensions = (
+        batch_size,
+        group_size,
+        prompt_tokens,
+        response_tokens,
+        layers,
+        top_k,
+        num_experts,
+        max_shard_bytes,
+        max_items_per_shard,
+        repeats,
+    )
+    if min(dimensions) < 1 or top_k > num_experts:
+        raise ValueError("dimensions must be positive and top_k <= num_experts")
+    if warmups < 0:
+        raise ValueError("warmups must be non-negative")
+    if not isinstance(level, RouteTraceLevel):
+        raise ValueError("level must be RouteTraceLevel")
+
+    rollout_id = "rollout-route-transport-benchmark"
+    tensors, traces = build_rollout_inputs(
+        batch_size=batch_size,
+        group_size=group_size,
+        prompt_tokens=prompt_tokens,
+        response_tokens=response_tokens,
+        layers=layers,
+        top_k=top_k,
+        num_experts=num_experts,
+        level=level,
+        device=torch.device("cpu"),
+        rollout_id=rollout_id,
+    )
+    batch = RolloutRouteTraceBatchV0.bind(
+        rollout_id=rollout_id,
+        policy_version=17,
+        traces=traces,
+        **tensors,
+    )
+
+    def build() -> RolloutRouteTraceTransportV0:
+        return RolloutRouteTraceTransportV0.from_batch(
+            batch,
+            max_shard_bytes=max_shard_bytes,
+            max_items_per_shard=max_items_per_shard,
+        )
+
+    transport = build()
+    for _ in range(warmups):
+        for shard_index, payload in enumerate(transport.shard_payloads):
+            transport.manifest.verify_shard(shard_index, payload)
+        transport.assemble()
+
+    build_us = []
+    verify_all_us = []
+    assemble_us = []
+    for _ in range(repeats):
+        started = time.perf_counter_ns()
+        candidate = build()
+        build_us.append((time.perf_counter_ns() - started) / 1000)
+        if candidate.manifest != transport.manifest:
+            raise RuntimeError("route shard manifest is not deterministic")
+        if candidate.shard_payloads != transport.shard_payloads:
+            raise RuntimeError("route shard frames are not deterministic")
+
+        started = time.perf_counter_ns()
+        for shard_index, payload in enumerate(transport.shard_payloads):
+            transport.manifest.verify_shard(shard_index, payload)
+        verify_all_us.append((time.perf_counter_ns() - started) / 1000)
+
+        started = time.perf_counter_ns()
+        restored = transport.assemble()
+        assemble_us.append((time.perf_counter_ns() - started) / 1000)
+        if restored.artifact_digest != batch.artifact_digest:
+            raise RuntimeError("route shard reconstruction changed batch identity")
+
+    manifest_nbytes = len(transport.manifest.dumps())
+    encoded_shard_nbytes = transport.manifest.encoded_nbytes
+    metadata_nbytes = manifest_nbytes + encoded_shard_nbytes - batch.payload_nbytes
+    assignment = {}
+    for world_size in (2, 4):
+        per_rank = [
+            sum(
+                len(payload)
+                for _, payload in transport.payloads_for_rank(rank, world_size)
+            )
+            for rank in range(world_size)
+        ]
+        assignment[str(world_size)] = {
+            "per_rank_encoded_nbytes": per_rank,
+            "peak_rank_encoded_nbytes": max(per_rank),
+        }
+
+    return {
+        "artifact_digest": batch.artifact_digest,
+        "benchmark": "astrai-rollout-route-trace-sharded-transport-v0",
+        "bytes": {
+            "encoded_shards": encoded_shard_nbytes,
+            "largest_shard": max(
+                descriptor.encoded_nbytes for descriptor in transport.manifest.shards
+            ),
+            "manifest": manifest_nbytes,
+            "metadata": metadata_nbytes,
+            "metadata_overhead_fraction": metadata_nbytes / batch.payload_nbytes,
+            "trace_payloads": batch.payload_nbytes,
+            "transport_total": transport.transport_nbytes,
+        },
+        "latency_us": {
+            "assemble": _latency_summary(assemble_us),
+            "build": _latency_summary(build_us),
+            "verify_all": _latency_summary(verify_all_us),
+        },
+        "parameters": {
+            "batch_size": batch_size,
+            "group_size": group_size,
+            "layers": layers,
+            "level": level.value,
+            "max_items_per_shard": max_items_per_shard,
+            "max_shard_bytes": max_shard_bytes,
+            "num_experts": num_experts,
+            "prompt_tokens": prompt_tokens,
+            "repeats": repeats,
+            "response_tokens": response_tokens,
+            "top_k": top_k,
+            "warmups": warmups,
+        },
+        "rank_assignment": assignment,
+        "schema_version": 1,
+        "scope": (
+            "CPU framing/verification/reconstruction only; excludes model capture, "
+            "network transport, generation, replay, scoring, and training"
+        ),
+        "shard_count": len(transport.shard_payloads),
+        "torch_version": torch.__version__,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--batch-size", type=_positive_int, default=8)
+    parser.add_argument("--group-size", type=_positive_int, default=8)
+    parser.add_argument("--prompt-tokens", type=_positive_int, default=512)
+    parser.add_argument("--response-tokens", type=_positive_int, default=1024)
+    parser.add_argument("--layers", type=_positive_int, default=40)
+    parser.add_argument("--top-k", type=_positive_int, default=22)
+    parser.add_argument("--num-experts", type=_positive_int, default=512)
+    parser.add_argument(
+        "--level",
+        choices=[level.value for level in RouteTraceLevel],
+        default=RouteTraceLevel.IDS.value,
+    )
+    parser.add_argument(
+        "--max-shard-bytes",
+        type=_positive_int,
+        default=16 * 1024 * 1024,
+    )
+    parser.add_argument("--max-items-per-shard", type=_positive_int, default=8)
+    parser.add_argument("--warmups", type=int, default=2)
+    parser.add_argument("--repeats", type=_positive_int, default=5)
+    parser.add_argument("--output-json", type=Path)
+    args = parser.parse_args()
+    if args.warmups < 0:
+        parser.error("--warmups must be non-negative")
+    if args.top_k > args.num_experts:
+        parser.error("--top-k must not exceed --num-experts")
+
+    report = run_benchmark(
+        batch_size=args.batch_size,
+        group_size=args.group_size,
+        prompt_tokens=args.prompt_tokens,
+        response_tokens=args.response_tokens,
+        layers=args.layers,
+        top_k=args.top_k,
+        num_experts=args.num_experts,
+        level=RouteTraceLevel(args.level),
+        max_shard_bytes=args.max_shard_bytes,
+        max_items_per_shard=args.max_items_per_shard,
+        warmups=args.warmups,
+        repeats=args.repeats,
+    )
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_route_trace_codec.py
+++ b/scripts/benchmark_route_trace_codec.py
@@ -1,0 +1,237 @@
+"""Measure RouteTraceV0 codec cost without changing model execution.
+
+This is a serialization microbenchmark, not a capture, replay, training, or
+end-to-end performance benchmark. It emits enough geometry and byte accounting
+to compare compact ID tiers on a specific host.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import time
+from pathlib import Path
+
+import torch
+
+from astrai.moe import (
+    PaddingLayout,
+    RouteIdentityV0,
+    RouterSchemaV0,
+    RouteTokenLayoutV0,
+    RouteTraceCodecV0,
+    RouteTraceLevel,
+    RouteTraceV0,
+    SelectedWeightSemantics,
+    TokenSpanKind,
+    canonical_json_digest,
+    pack_route_ids,
+)
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    ordered = sorted(values)
+    index = max(0, math.ceil(percentile * len(ordered)) - 1)
+    return ordered[index]
+
+
+def _synchronize(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def build_trace(
+    *,
+    tokens: int,
+    layers: int,
+    top_k: int,
+    num_experts: int,
+    level: RouteTraceLevel,
+    device: torch.device,
+) -> RouteTraceV0:
+    """Build one deterministic, valid codec benchmark artifact."""
+    if min(tokens, layers, top_k, num_experts) < 1 or top_k > num_experts:
+        raise ValueError(
+            "tokens/layers/top_k/num_experts must be positive and top_k <= num_experts"
+        )
+    schema = RouterSchemaV0(
+        num_moe_layers=layers,
+        num_experts=num_experts,
+        top_k=top_k,
+        expert_parallel_world_size=1,
+        score_function="synthetic-softmax-fp32-before-topk",
+        score_dtype="float32",
+        expert_id_ordering="score-descending-stable-index",
+        selected_weight_semantics=SelectedWeightSemantics.SELECTED_RENORMALIZED,
+        token_ordering="single-sequence-token-major",
+        padding_layout=PaddingLayout.NONE,
+        backend="codec-benchmark",
+        kernel_semantics_version="synthetic-v0",
+        parallel_layout_hash=canonical_json_digest({"placement": "all-experts-local"}),
+    )
+    identity = RouteIdentityV0(
+        policy_version=0,
+        model_revision="synthetic-model",
+        router_state_version=0,
+        checkpoint_revision="synthetic-checkpoint",
+        router_schema_hash=schema.fingerprint,
+    )
+    token_layout = RouteTokenLayoutV0(
+        sample_id="codec-benchmark-sample",
+        sequence_token_count=tokens,
+        prompt_token_count=0,
+        token_offset=0,
+        token_count=tokens,
+        span_kind=TokenSpanKind.FULL_SEQUENCE,
+    )
+    row = torch.arange(top_k, dtype=torch.int64)
+    row_offsets = torch.arange(tokens * layers, dtype=torch.int64).reshape(
+        tokens, layers, 1
+    )
+    topk_ids = pack_route_ids((row + row_offsets) % num_experts, num_experts).to(device)
+    selected_weights = None
+    topk_margin = None
+    if level is RouteTraceLevel.IDS_WEIGHTS_MARGIN:
+        selected_weights = torch.full(
+            (tokens, layers, top_k),
+            1.0 / top_k,
+            dtype=torch.float16,
+            device=device,
+        )
+        topk_margin = torch.full(
+            (tokens, layers), 0.125, dtype=torch.float16, device=device
+        )
+    return RouteTraceV0(
+        identity=identity,
+        router_schema=schema,
+        token_layout=token_layout,
+        level=level,
+        topk_ids=topk_ids,
+        selected_weights=selected_weights,
+        topk_margin=topk_margin,
+    )
+
+
+def run_benchmark(
+    *,
+    tokens: int,
+    layers: int,
+    top_k: int,
+    num_experts: int,
+    level: RouteTraceLevel,
+    device: torch.device,
+    warmups: int,
+    repeats: int,
+) -> dict:
+    """Return deterministic byte accounting and measured codec latency."""
+    if warmups < 0 or repeats < 1:
+        raise ValueError("warmups must be non-negative and repeats must be positive")
+    trace = build_trace(
+        tokens=tokens,
+        layers=layers,
+        top_k=top_k,
+        num_experts=num_experts,
+        level=level,
+        device=device,
+    )
+    for _ in range(warmups):
+        RouteTraceCodecV0.loads(RouteTraceCodecV0.dumps(trace))
+
+    serialize_us = []
+    deserialize_us = []
+    blob = b""
+    restored = None
+    for _ in range(repeats):
+        _synchronize(device)
+        started = time.perf_counter_ns()
+        blob = RouteTraceCodecV0.dumps(trace)
+        _synchronize(device)
+        encoded = time.perf_counter_ns()
+        restored = RouteTraceCodecV0.loads(blob)
+        finished = time.perf_counter_ns()
+        serialize_us.append((encoded - started) / 1000)
+        deserialize_us.append((finished - encoded) / 1000)
+    assert restored is not None
+    if restored.artifact_digest != trace.artifact_digest:
+        raise RuntimeError("codec benchmark round-trip changed artifact identity")
+
+    return {
+        "schema_version": 1,
+        "benchmark": "astrai-route-trace-codec-v0",
+        "scope": "codec-only; excludes model capture, transport, replay, and training",
+        "device": str(device),
+        "torch_version": torch.__version__,
+        "parameters": {
+            "tokens": tokens,
+            "layers": layers,
+            "top_k": top_k,
+            "num_experts": num_experts,
+            "level": level.value,
+            "warmups": warmups,
+            "repeats": repeats,
+        },
+        "bytes": {
+            "logical_payload": trace.payload_nbytes,
+            "wire": len(blob),
+            "wire_per_token": len(blob) / tokens,
+            "int64_ids_only_baseline": tokens * layers * top_k * 8,
+        },
+        "latency_us": {
+            "serialize_median": statistics.median(serialize_us),
+            "serialize_p95": _percentile(serialize_us, 0.95),
+            "deserialize_median": statistics.median(deserialize_us),
+            "deserialize_p95": _percentile(deserialize_us, 0.95),
+        },
+        "artifact_digest": trace.artifact_digest,
+    }
+
+
+def main() -> None:
+    """Run the codec benchmark and emit one JSON report."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tokens", type=_positive_int, default=1024)
+    parser.add_argument("--layers", type=_positive_int, default=16)
+    parser.add_argument("--top-k", type=_positive_int, default=2)
+    parser.add_argument("--num-experts", type=_positive_int, default=64)
+    parser.add_argument(
+        "--level", choices=[level.value for level in RouteTraceLevel], default="ids"
+    )
+    parser.add_argument("--device", choices=("cpu", "cuda"), default="cpu")
+    parser.add_argument("--warmups", type=int, default=3)
+    parser.add_argument("--repeats", type=_positive_int, default=20)
+    parser.add_argument("--output-json", type=Path)
+    args = parser.parse_args()
+    if args.warmups < 0:
+        parser.error("--warmups must be non-negative")
+    if args.top_k > args.num_experts:
+        parser.error("--top-k must not exceed --num-experts")
+    if args.device == "cuda" and not torch.cuda.is_available():
+        parser.error("--device cuda requires an available CUDA device")
+    report = run_benchmark(
+        tokens=args.tokens,
+        layers=args.layers,
+        top_k=args.top_k,
+        num_experts=args.num_experts,
+        level=RouteTraceLevel(args.level),
+        device=torch.device(args.device),
+        warmups=args.warmups,
+        repeats=args.repeats,
+    )
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/moe/test_route_metrics.py
+++ b/tests/moe/test_route_metrics.py
@@ -1,0 +1,182 @@
+"""Tests for pure route-alignment and near-tie diagnostics."""
+
+from dataclasses import replace
+
+import pytest
+import torch
+
+from astrai.moe import (
+    PaddingLayout,
+    RouteIdentityV0,
+    RouterSchemaV0,
+    RouteTokenLayoutV0,
+    RouteTraceLevel,
+    RouteTraceV0,
+    RouteTraceValidationError,
+    SelectedWeightSemantics,
+    TokenSpanKind,
+    canonical_json_digest,
+    compare_route_traces,
+    compute_topk_margin,
+    pack_route_ids,
+)
+
+
+def _metric_trace(
+    ids, weights=None, margins=None, *, policy_version=0, valid_mask=None
+):
+    padding_layout = (
+        PaddingLayout.EXPLICIT_MASK if valid_mask is not None else PaddingLayout.NONE
+    )
+    schema = RouterSchemaV0(
+        num_moe_layers=1,
+        num_experts=8,
+        top_k=2,
+        expert_parallel_world_size=1,
+        score_function="softmax-fp32-before-topk",
+        score_dtype="float32",
+        expert_id_ordering="score-descending-stable-index",
+        selected_weight_semantics=SelectedWeightSemantics.SELECTED_RENORMALIZED,
+        token_ordering="single-sequence-token-major",
+        padding_layout=padding_layout,
+        backend="unit-test",
+        kernel_semantics_version="torch-topk-v1",
+        parallel_layout_hash=canonical_json_digest({"placement": "local"}),
+    )
+    identity = RouteIdentityV0(
+        policy_version=policy_version,
+        model_revision=f"model-{policy_version}",
+        router_state_version=policy_version,
+        checkpoint_revision=f"checkpoint-{policy_version}",
+        router_schema_hash=schema.fingerprint,
+    )
+    token_layout = RouteTokenLayoutV0(
+        sample_id="sample",
+        sequence_token_count=2,
+        prompt_token_count=0,
+        token_offset=0,
+        token_count=2,
+        span_kind=TokenSpanKind.FULL_SEQUENCE,
+    )
+    level = (
+        RouteTraceLevel.IDS_WEIGHTS_MARGIN
+        if weights is not None and margins is not None
+        else RouteTraceLevel.IDS
+    )
+    mask_tensor = (
+        torch.tensor(valid_mask, dtype=torch.bool) if valid_mask is not None else None
+    )
+    topk_ids = pack_route_ids(torch.tensor(ids).reshape(2, 1, 2), schema.num_experts)
+    if mask_tensor is not None:
+        topk_ids[~mask_tensor] = 0
+    return RouteTraceV0(
+        identity=identity,
+        router_schema=schema,
+        token_layout=token_layout,
+        level=level,
+        topk_ids=topk_ids,
+        selected_weights=(
+            torch.tensor(weights, dtype=torch.float16).reshape(2, 1, 2)
+            if weights is not None
+            else None
+        ),
+        topk_margin=(
+            torch.tensor(margins, dtype=torch.float16).reshape(2, 1)
+            if margins is not None
+            else None
+        ),
+        valid_mask=mask_tensor,
+    )
+
+
+def test_alignment_metrics_distinguish_order_set_mass_and_fragility():
+    behavior = _metric_trace(
+        [[0, 1], [2, 3]],
+        [[0.7, 0.3], [0.6, 0.4]],
+        [0.01, 0.20],
+        policy_version=4,
+    )
+    current = _metric_trace(
+        [[1, 0], [2, 4]],
+        [[0.3, 0.7], [0.5, 0.5]],
+        [0.02, 0.30],
+        policy_version=5,
+    )
+
+    metrics = compare_route_traces(behavior, current, fragile_margin_threshold=0.05)
+
+    assert metrics.behavior_policy_version == 4
+    assert metrics.current_policy_version == 5
+    assert metrics.valid_token_count == 2
+    assert metrics.compared_token_layer_count == 2
+    assert metrics.ordered_topk_match_fraction == 0.0
+    assert metrics.unordered_topk_overlap_fraction == pytest.approx(0.75)
+    assert metrics.route_set_flip_fraction == pytest.approx(0.25)
+    assert metrics.selected_weight_l1_mean == pytest.approx(0.5, abs=1e-3)
+    assert metrics.behavior_margin_mean == pytest.approx(0.105, abs=1e-3)
+    assert metrics.behavior_fragile_fraction == pytest.approx(0.5)
+    assert metrics.to_dict()["fragile_margin_threshold"] == 0.05
+
+
+def test_ids_only_metrics_do_not_fabricate_gate_or_margin_values():
+    behavior = _metric_trace([[0, 1], [2, 3]], policy_version=0)
+    current = _metric_trace([[0, 1], [2, 4]], policy_version=1)
+
+    metrics = compare_route_traces(behavior, current)
+
+    assert metrics.ordered_topk_match_fraction == 0.5
+    assert metrics.unordered_topk_overlap_fraction == 0.75
+    assert metrics.selected_weight_l1_mean is None
+    assert metrics.behavior_margin_mean is None
+    assert metrics.behavior_fragile_fraction is None
+    with pytest.raises(RouteTraceValidationError, match="require behavior topk_margin"):
+        compare_route_traces(behavior, current, fragile_margin_threshold=0.1)
+
+
+def test_metrics_require_exact_schema_layout_mask_and_device_semantics():
+    behavior = _metric_trace([[0, 1], [2, 3]], valid_mask=[True, False])
+    current = _metric_trace([[0, 1], [2, 3]], policy_version=1, valid_mask=[True, True])
+    with pytest.raises(RouteTraceValidationError, match="validity masks"):
+        compare_route_traces(behavior, current)
+
+    schema = replace(current.router_schema, backend="different")
+    identity = replace(current.identity, router_schema_hash=schema.fingerprint)
+    mismatched_schema = replace(current, router_schema=schema, identity=identity)
+    with pytest.raises(RouteTraceValidationError, match="router schema"):
+        compare_route_traces(behavior, mismatched_schema)
+
+
+def test_metrics_reject_empty_valid_population_and_bad_threshold():
+    behavior = _metric_trace([[0, 0], [0, 0]], valid_mask=[False, False])
+    current = _metric_trace(
+        [[0, 0], [0, 0]], policy_version=1, valid_mask=[False, False]
+    )
+    with pytest.raises(RouteTraceValidationError, match="at least one valid"):
+        compare_route_traces(behavior, current)
+    valid = _metric_trace([[0, 1], [2, 3]])
+    with pytest.raises(RouteTraceValidationError, match="finite non-negative"):
+        compare_route_traces(valid, valid, fragile_margin_threshold=float("nan"))
+
+
+def test_bfloat16_near_tie_margin_uses_explicit_fp32_reference():
+    scores = torch.tensor(
+        [[1.0, 0.984375, 0.5], [1.0, 1.0, 0.25]], dtype=torch.bfloat16
+    )
+
+    margin = compute_topk_margin(scores, top_k=1)
+
+    torch.testing.assert_close(margin, compute_topk_margin(scores.float(), top_k=1))
+    assert margin.dtype is torch.float32
+    assert margin.tolist() == pytest.approx([0.015625, 0.0])
+
+
+@pytest.mark.parametrize("top_k", [0, 3, True])
+def test_margin_rejects_invalid_top_k(top_k):
+    with pytest.raises(RouteTraceValidationError, match="top_k|top-k"):
+        compute_topk_margin(torch.ones(2, 3), top_k)
+
+
+def test_margin_rejects_nonfinite_scores():
+    scores = torch.tensor([[1.0, float("nan"), 0.0]])
+    with pytest.raises(RouteTraceValidationError, match="finite"):
+        compute_topk_margin(scores, 1)

--- a/tests/moe/test_route_trace.py
+++ b/tests/moe/test_route_trace.py
@@ -1,0 +1,453 @@
+"""Tests for the version-zero semantic MoE route trace contract."""
+
+import json
+from dataclasses import replace
+
+import pytest
+import safetensors.torch as safetensors
+import torch
+
+from astrai.moe import (
+    ROUTE_TRACE_SCHEMA_VERSION,
+    PaddingLayout,
+    RouteIdentityV0,
+    RouterSchemaV0,
+    RouteTokenLayoutV0,
+    RouteTraceCodecV0,
+    RouteTraceLevel,
+    RouteTraceV0,
+    RouteTraceValidationError,
+    SelectedWeightSemantics,
+    TokenSpanKind,
+    canonical_json_digest,
+    pack_route_ids,
+    recommended_route_id_dtype,
+    require_compatible_route_trace,
+    validate_route_trace,
+)
+
+_MANIFEST_TENSOR = "__route_trace_manifest_v0__"
+
+
+def _schema(
+    *,
+    num_experts=8,
+    padding_layout=PaddingLayout.RIGHT,
+    backend="astrai-torch",
+):
+    return RouterSchemaV0(
+        num_moe_layers=2,
+        num_experts=num_experts,
+        top_k=2,
+        expert_parallel_world_size=1,
+        score_function="softmax-fp32-before-topk",
+        score_dtype="float32",
+        expert_id_ordering="score-descending-stable-index",
+        selected_weight_semantics=SelectedWeightSemantics.SELECTED_RENORMALIZED,
+        token_ordering="single-sequence-token-major",
+        padding_layout=padding_layout,
+        backend=backend,
+        kernel_semantics_version="torch-topk-v1",
+        parallel_layout_hash=canonical_json_digest(
+            {"expert_parallel_world_size": 1, "placement": "all-experts-local"}
+        ),
+    )
+
+
+def _trace(*, num_experts=8, level=RouteTraceLevel.IDS_WEIGHTS_MARGIN):
+    schema = _schema(num_experts=num_experts)
+    identity = RouteIdentityV0(
+        policy_version=7,
+        model_revision="model-revision-7",
+        router_state_version=11,
+        checkpoint_revision="checkpoint-7",
+        router_schema_hash=schema.fingerprint,
+        load_controller_version=3,
+    )
+    token_layout = RouteTokenLayoutV0(
+        sample_id="sample-17",
+        sequence_token_count=6,
+        prompt_token_count=2,
+        token_offset=2,
+        token_count=4,
+        span_kind=TokenSpanKind.RESPONSE,
+    )
+    topk_ids = pack_route_ids(
+        torch.tensor(
+            [
+                [[0, 1], [2, 3]],
+                [[1, 2], [3, 4]],
+                [[2, 3], [4, 5]],
+                [[0, 0], [0, 0]],
+            ]
+        ),
+        num_experts,
+    )
+    valid_mask = torch.tensor([True, True, True, False])
+    if level is RouteTraceLevel.IDS:
+        return RouteTraceV0(
+            identity=identity,
+            router_schema=schema,
+            token_layout=token_layout,
+            level=level,
+            topk_ids=topk_ids,
+            valid_mask=valid_mask,
+        )
+    selected_weights = torch.tensor(
+        [
+            [[0.75, 0.25], [0.60, 0.40]],
+            [[0.55, 0.45], [0.80, 0.20]],
+            [[0.50, 0.50], [0.65, 0.35]],
+            [[0.00, 0.00], [0.00, 0.00]],
+        ],
+        dtype=torch.float16,
+    )
+    topk_margin = torch.tensor(
+        [[0.20, 0.10], [0.01, 0.30], [0.05, 0.25], [0.00, 0.00]],
+        dtype=torch.float16,
+    )
+    return RouteTraceV0(
+        identity=identity,
+        router_schema=schema,
+        token_layout=token_layout,
+        level=level,
+        topk_ids=topk_ids,
+        selected_weights=selected_weights,
+        topk_margin=topk_margin,
+        valid_mask=valid_mask,
+    )
+
+
+def _rewrite_manifest(blob, mutate):
+    tensors = safetensors.load(blob)
+    manifest = json.loads(bytes(tensors[_MANIFEST_TENSOR].tolist()))
+    mutate(manifest, tensors)
+    manifest_bytes = json.dumps(
+        manifest, sort_keys=True, separators=(",", ":")
+    ).encode()
+    tensors[_MANIFEST_TENSOR] = torch.tensor(list(manifest_bytes), dtype=torch.uint8)
+    return safetensors.save(tensors)
+
+
+@pytest.mark.parametrize(
+    ("num_experts", "expected_dtype"),
+    [
+        (8, torch.uint8),
+        (256, torch.uint8),
+        (257, torch.uint16),
+        (65536, torch.uint16),
+        (65537, torch.uint32),
+    ],
+)
+def test_route_id_dtype_is_narrow_and_codec_round_trips(num_experts, expected_dtype):
+    trace = _trace(num_experts=num_experts)
+
+    blob = RouteTraceCodecV0.dumps(trace)
+    restored = RouteTraceCodecV0.loads(blob)
+
+    assert restored.topk_ids.dtype is expected_dtype
+    assert restored.identity == trace.identity
+    assert restored.router_schema == trace.router_schema
+    assert restored.token_layout == trace.token_layout
+    assert restored.level is RouteTraceLevel.IDS_WEIGHTS_MARGIN
+    assert restored.valid_token_count == 3
+    assert (
+        restored.payload_nbytes
+        == 52 + 16 * torch.empty((), dtype=expected_dtype).element_size()
+    )
+    assert torch.equal(restored.topk_ids, trace.topk_ids.cpu())
+    assert torch.equal(restored.selected_weights, trace.selected_weights.cpu())
+    assert torch.equal(restored.topk_margin, trace.topk_margin.cpu())
+    assert torch.equal(restored.valid_mask, trace.valid_mask.cpu())
+    assert RouteTraceCodecV0.dumps(restored) == blob
+    assert restored.artifact_digest == trace.artifact_digest
+
+
+def test_ids_only_level_round_trips_without_fabricating_optional_metrics():
+    trace = _trace(level=RouteTraceLevel.IDS)
+
+    restored = RouteTraceCodecV0.loads(RouteTraceCodecV0.dumps(trace))
+
+    assert restored.selected_weights is None
+    assert restored.topk_margin is None
+    assert restored.valid_mask is not None
+
+
+@pytest.mark.parametrize("num_experts", [0, -1, 2**32 + 1, True])
+def test_recommended_dtype_rejects_invalid_expert_counts(num_experts):
+    with pytest.raises(RouteTraceValidationError, match="num_experts"):
+        recommended_route_id_dtype(num_experts)
+
+
+def test_pack_route_ids_rejects_negative_and_out_of_range_values():
+    with pytest.raises(RouteTraceValidationError, match="outside the declared range"):
+        pack_route_ids(torch.tensor([[[-1, 0]]]), 8)
+    with pytest.raises(RouteTraceValidationError, match="outside the declared range"):
+        pack_route_ids(torch.tensor([[[0, 8]]]), 8)
+    with pytest.raises(RouteTraceValidationError, match="integer dtype"):
+        pack_route_ids(torch.tensor([[[0.0, 1.0]]]), 8)
+
+
+@pytest.mark.parametrize("policy_version", [-1, True, 1.5])
+def test_identity_rejects_invalid_policy_version(policy_version):
+    schema = _schema()
+    with pytest.raises(RouteTraceValidationError, match="policy_version"):
+        RouteIdentityV0(
+            policy_version=policy_version,
+            model_revision="model",
+            router_state_version=0,
+            checkpoint_revision="checkpoint",
+            router_schema_hash=schema.fingerprint,
+        )
+
+
+def test_schema_hash_mismatch_fails_closed():
+    trace = _trace()
+    bad_identity = replace(trace.identity, router_schema_hash="0" * 64)
+
+    with pytest.raises(RouteTraceValidationError, match="router_schema_hash"):
+        replace(trace, identity=bad_identity)
+
+
+@pytest.mark.parametrize(
+    ("layout", "message"),
+    [
+        (
+            RouteTokenLayoutV0(
+                sample_id="sample",
+                sequence_token_count=8,
+                prompt_token_count=3,
+                token_offset=3,
+                token_count=2,
+                span_kind=TokenSpanKind.RESPONSE,
+            ),
+            None,
+        ),
+    ],
+)
+def test_valid_token_layout(layout, message):
+    assert layout.token_offset == 3
+    assert message is None
+
+
+def test_invalid_token_boundaries_fail_closed():
+    with pytest.raises(RouteTraceValidationError, match="exceeds"):
+        RouteTokenLayoutV0(
+            sample_id="sample",
+            sequence_token_count=4,
+            prompt_token_count=2,
+            token_offset=3,
+            token_count=2,
+            span_kind=TokenSpanKind.CONTIGUOUS,
+        )
+    with pytest.raises(RouteTraceValidationError, match="inside the prompt"):
+        RouteTokenLayoutV0(
+            sample_id="sample",
+            sequence_token_count=4,
+            prompt_token_count=2,
+            token_offset=1,
+            token_count=2,
+            span_kind=TokenSpanKind.RESPONSE,
+        )
+    with pytest.raises(RouteTraceValidationError, match="exactly cover"):
+        RouteTokenLayoutV0(
+            sample_id="sample",
+            sequence_token_count=4,
+            prompt_token_count=2,
+            token_offset=0,
+            token_count=1,
+            span_kind=TokenSpanKind.PROMPT,
+        )
+
+
+def test_tensor_shape_dtype_range_and_uniqueness_are_strict():
+    trace = _trace()
+    with pytest.raises(RouteTraceValidationError, match="shape"):
+        replace(trace, topk_ids=trace.topk_ids[:3])
+    with pytest.raises(RouteTraceValidationError, match="compact dtype"):
+        replace(trace, topk_ids=trace.topk_ids.to(torch.int64))
+    out_of_range = trace.topk_ids.clone()
+    out_of_range[0, 0, 0] = trace.router_schema.num_experts
+    with pytest.raises(RouteTraceValidationError, match="outside the declared range"):
+        replace(trace, topk_ids=out_of_range)
+    duplicate = trace.topk_ids.clone()
+    duplicate[0, 0] = duplicate[0, 0, 0]
+    with pytest.raises(RouteTraceValidationError, match="duplicate experts"):
+        replace(trace, topk_ids=duplicate)
+    with pytest.raises(RouteTraceValidationError, match="materialized strided"):
+        replace(
+            trace,
+            topk_ids=torch.empty(
+                trace.topk_ids.shape, dtype=trace.topk_ids.dtype, device="meta"
+            ),
+        )
+
+
+def test_padding_mask_and_invalid_rows_must_be_canonical():
+    trace = _trace()
+    with pytest.raises(RouteTraceValidationError, match="right padding"):
+        replace(trace, valid_mask=torch.tensor([True, False, True, False]))
+    invalid_ids = trace.topk_ids.clone()
+    invalid_ids[-1, 0, 0] = 1
+    with pytest.raises(RouteTraceValidationError, match="canonical zero expert"):
+        replace(trace, topk_ids=invalid_ids)
+    invalid_weights = trace.selected_weights.clone()
+    invalid_weights[-1, 0, 0] = 1
+    with pytest.raises(RouteTraceValidationError, match="canonical zero weights"):
+        replace(trace, selected_weights=invalid_weights)
+
+
+def test_explicit_padding_requires_a_mask():
+    trace = _trace()
+    schema = replace(trace.router_schema, padding_layout=PaddingLayout.EXPLICIT_MASK)
+    identity = replace(trace.identity, router_schema_hash=schema.fingerprint)
+    with pytest.raises(RouteTraceValidationError, match="requires valid_mask"):
+        replace(trace, router_schema=schema, identity=identity, valid_mask=None)
+
+
+def test_weight_and_margin_contract_rejects_invalid_values():
+    trace = _trace()
+    wrong_sum = trace.selected_weights.clone()
+    wrong_sum[0, 0] = torch.tensor([0.2, 0.2])
+    with pytest.raises(RouteTraceValidationError, match="sum to one"):
+        replace(trace, selected_weights=wrong_sum)
+    nan_margin = trace.topk_margin.clone()
+    nan_margin[0, 0] = float("nan")
+    with pytest.raises(RouteTraceValidationError, match="finite"):
+        replace(trace, topk_margin=nan_margin)
+    with pytest.raises(RouteTraceValidationError, match="cannot carry"):
+        replace(trace, level=RouteTraceLevel.IDS)
+    with pytest.raises(RouteTraceValidationError, match="requires weights"):
+        replace(trace, selected_weights=None, topk_margin=None)
+    with pytest.raises(RouteTraceValidationError, match="torch.Tensor"):
+        replace(trace, selected_weights="not-a-tensor")
+    negative_zero = trace.topk_margin.clone()
+    negative_zero[0, 0] = -0.0
+    with pytest.raises(RouteTraceValidationError, match="canonical positive zero"):
+        replace(trace, topk_margin=negative_zero)
+
+
+def test_full_softmax_selected_mass_allows_subunit_mass_only():
+    trace = _trace()
+    schema = replace(
+        trace.router_schema,
+        selected_weight_semantics=SelectedWeightSemantics.FULL_SOFTMAX_SELECTED,
+    )
+    identity = replace(trace.identity, router_schema_hash=schema.fingerprint)
+    weights = trace.selected_weights * 0.5
+    valid = replace(
+        trace, router_schema=schema, identity=identity, selected_weights=weights
+    )
+    validate_route_trace(valid)
+    too_large = weights.clone()
+    too_large[0, 0] = torch.tensor([0.8, 0.4])
+    with pytest.raises(RouteTraceValidationError, match="selected mass"):
+        replace(valid, selected_weights=too_large)
+
+
+def test_exact_consumer_compatibility_rejects_every_identity_or_semantic_mismatch():
+    trace = _trace()
+    require_compatible_route_trace(
+        trace,
+        expected_identity=trace.identity,
+        expected_router_schema=trace.router_schema,
+        expected_token_layout=trace.token_layout,
+        minimum_level=RouteTraceLevel.IDS_WEIGHTS_MARGIN,
+    )
+    with pytest.raises(RouteTraceValidationError, match="route identity"):
+        require_compatible_route_trace(
+            trace,
+            expected_identity=replace(trace.identity, policy_version=8),
+            expected_router_schema=trace.router_schema,
+            expected_token_layout=trace.token_layout,
+        )
+    with pytest.raises(RouteTraceValidationError, match="router schema"):
+        require_compatible_route_trace(
+            trace,
+            expected_identity=trace.identity,
+            expected_router_schema=replace(
+                trace.router_schema, backend="other-backend"
+            ),
+            expected_token_layout=trace.token_layout,
+        )
+    with pytest.raises(RouteTraceValidationError, match="token layout"):
+        require_compatible_route_trace(
+            trace,
+            expected_identity=trace.identity,
+            expected_router_schema=trace.router_schema,
+            expected_token_layout=replace(trace.token_layout, sample_id="other-sample"),
+        )
+    ids_only = _trace(level=RouteTraceLevel.IDS)
+    with pytest.raises(RouteTraceValidationError, match="does not satisfy"):
+        require_compatible_route_trace(
+            ids_only,
+            expected_identity=ids_only.identity,
+            expected_router_schema=ids_only.router_schema,
+            expected_token_layout=ids_only.token_layout,
+            minimum_level=RouteTraceLevel.IDS_WEIGHTS_MARGIN,
+        )
+
+
+def test_codec_rejects_unknown_schema_fields_versions_and_tensors():
+    blob = RouteTraceCodecV0.dumps(_trace())
+    unknown_field = _rewrite_manifest(
+        blob, lambda manifest, _: manifest.update({"future": 1})
+    )
+    with pytest.raises(RouteTraceValidationError, match="manifest keys"):
+        RouteTraceCodecV0.loads(unknown_field)
+    future_version = _rewrite_manifest(
+        blob,
+        lambda manifest, _: manifest.update(
+            {"route_trace_schema_version": ROUTE_TRACE_SCHEMA_VERSION + 1}
+        ),
+    )
+    with pytest.raises(
+        RouteTraceValidationError, match="unsupported route trace schema version"
+    ):
+        RouteTraceCodecV0.loads(future_version)
+    boolean_version = _rewrite_manifest(
+        blob,
+        lambda manifest, _: manifest.update({"route_trace_schema_version": False}),
+    )
+    with pytest.raises(
+        RouteTraceValidationError, match="unsupported route trace schema version"
+    ):
+        RouteTraceCodecV0.loads(boolean_version)
+    wrong_byte_order = _rewrite_manifest(
+        blob, lambda manifest, _: manifest.update({"byte_order": "big"})
+    )
+    with pytest.raises(
+        RouteTraceValidationError, match="unsupported route trace byte order"
+    ):
+        RouteTraceCodecV0.loads(wrong_byte_order)
+
+    def add_tensor(_, tensors):
+        tensors["tensor.future"] = torch.zeros(1, dtype=torch.uint8)
+
+    extra_tensor = _rewrite_manifest(blob, add_tensor)
+    with pytest.raises(RouteTraceValidationError, match="tensor names"):
+        RouteTraceCodecV0.loads(extra_tensor)
+
+
+def test_codec_rejects_corruption_and_size_budget_violation():
+    blob = RouteTraceCodecV0.dumps(_trace())
+
+    def corrupt_ids(_, tensors):
+        tensors["tensor.topk_ids"][0] ^= 1
+
+    corrupted = _rewrite_manifest(blob, corrupt_ids)
+    with pytest.raises(RouteTraceValidationError, match="checksum mismatch"):
+        RouteTraceCodecV0.loads(corrupted)
+    with pytest.raises(RouteTraceValidationError, match="exceeds the size limit"):
+        RouteTraceCodecV0.loads(blob, max_serialized_bytes=len(blob) - 1)
+    with pytest.raises(RouteTraceValidationError, match="safetensors"):
+        RouteTraceCodecV0.loads(b"not-a-safetensors-file")
+
+
+def test_manifest_subobjects_are_strictly_versioned():
+    blob = RouteTraceCodecV0.dumps(_trace())
+    unknown_identity = _rewrite_manifest(
+        blob, lambda manifest, _: manifest["identity"].update({"future": 1})
+    )
+    with pytest.raises(RouteTraceValidationError, match="identity keys"):
+        RouteTraceCodecV0.loads(unknown_identity)

--- a/tests/moe/test_route_trace_benchmark.py
+++ b/tests/moe/test_route_trace_benchmark.py
@@ -1,0 +1,59 @@
+"""Tests for deterministic RouteTraceV0 codec benchmark setup and reporting."""
+
+import pytest
+import torch
+
+from astrai.moe import RouteTraceLevel
+from scripts.benchmark_route_trace_codec import build_trace, run_benchmark
+
+
+@pytest.mark.parametrize("level", list(RouteTraceLevel))
+def test_codec_benchmark_reports_scope_bytes_and_latency(level):
+    report = run_benchmark(
+        tokens=4,
+        layers=2,
+        top_k=2,
+        num_experts=8,
+        level=level,
+        device=torch.device("cpu"),
+        warmups=0,
+        repeats=2,
+    )
+
+    assert report["schema_version"] == 1
+    assert report["benchmark"] == "astrai-route-trace-codec-v0"
+    assert report["parameters"]["level"] == level.value
+    assert report["bytes"]["wire"] > report["bytes"]["logical_payload"]
+    assert report["bytes"]["wire_per_token"] > 0
+    assert report["latency_us"]["serialize_median"] > 0
+    assert report["latency_us"]["deserialize_median"] > 0
+    assert len(report["artifact_digest"]) == 64
+
+
+def test_codec_benchmark_builds_compact_ids_for_large_expert_count():
+    trace = build_trace(
+        tokens=2,
+        layers=1,
+        top_k=2,
+        num_experts=257,
+        level=RouteTraceLevel.IDS,
+        device=torch.device("cpu"),
+    )
+
+    assert trace.topk_ids.dtype is torch.uint16
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"tokens": 0, "layers": 1, "top_k": 1, "num_experts": 2},
+        {"tokens": 1, "layers": 1, "top_k": 3, "num_experts": 2},
+    ],
+)
+def test_codec_benchmark_rejects_invalid_geometry(kwargs):
+    with pytest.raises(ValueError):
+        build_trace(
+            **kwargs,
+            level=RouteTraceLevel.IDS,
+            device=torch.device("cpu"),
+        )

--- a/tests/trainer/test_rollout_route_trace.py
+++ b/tests/trainer/test_rollout_route_trace.py
@@ -1,0 +1,488 @@
+"""Tests for immutable RouteTraceV0 bindings at rollout cache boundaries."""
+
+from dataclasses import replace
+
+import pytest
+import torch
+
+from astrai.moe import (
+    PaddingLayout,
+    RouteIdentityV0,
+    RouterSchemaV0,
+    RouteTokenLayoutV0,
+    RouteTraceLevel,
+    RouteTraceV0,
+    SelectedWeightSemantics,
+    TokenSpanKind,
+    canonical_json_digest,
+    pack_route_ids,
+)
+from astrai.trainer.rollout import (
+    BaseRewardModel,
+    RawRollout,
+    RolloutRunner,
+)
+from astrai.trainer.route_trace import (
+    ROLLOUT_ROUTE_TRACE_SCHEMA_VERSION,
+    RolloutRouteTraceBatchV0,
+    RolloutRouteTraceError,
+    RolloutRouteTraceItemV0,
+    rollout_route_sample_id,
+)
+
+
+def _rollout_tensors():
+    prompts = torch.tensor([[0, 11, 12], [21, 22, 23]], dtype=torch.long)
+    prompt_mask = torch.tensor([[False, True, True], [True, True, True]])
+    responses = torch.tensor(
+        [
+            [[31, 32, 0, 0], [33, 34, 35, 0]],
+            [[41, 0, 0, 0], [42, 43, 44, 45]],
+        ],
+        dtype=torch.long,
+    )
+    response_mask = responses != 0
+    return prompts, prompt_mask, responses, response_mask
+
+
+def _schema():
+    return RouterSchemaV0(
+        num_moe_layers=2,
+        num_experts=8,
+        top_k=2,
+        expert_parallel_world_size=1,
+        score_function="softmax-fp32-before-topk",
+        score_dtype="float32",
+        expert_id_ordering="score-descending-stable-index",
+        selected_weight_semantics=SelectedWeightSemantics.SELECTED_RENORMALIZED,
+        token_ordering="rollout-batch-group-response-token-major",
+        padding_layout=PaddingLayout.RIGHT,
+        backend="unit-test",
+        kernel_semantics_version="torch-topk-v1",
+        parallel_layout_hash=canonical_json_digest({"placement": "all-local"}),
+    )
+
+
+def _trace_grid(
+    *, policy_version=3, level=RouteTraceLevel.IDS, rollout_id="rollout-17"
+):
+    prompts, prompt_mask, _, response_mask = _rollout_tensors()
+    schema = _schema()
+    identity = RouteIdentityV0(
+        policy_version=policy_version,
+        model_revision="model-3",
+        router_state_version=3,
+        checkpoint_revision="checkpoint-3",
+        router_schema_hash=schema.fingerprint,
+        load_controller_version=1,
+    )
+    traces = []
+    for batch_index in range(response_mask.shape[0]):
+        row = []
+        prompt_length = int(prompt_mask[batch_index].sum().item())
+        for group_index in range(response_mask.shape[1]):
+            mask = response_mask[batch_index, group_index].clone()
+            ids = torch.zeros(4, 2, 2, dtype=torch.int64)
+            for token_index in range(int(mask.sum().item())):
+                for layer_index in range(2):
+                    first = (batch_index + group_index + token_index + layer_index) % 8
+                    ids[token_index, layer_index] = torch.tensor(
+                        [first, (first + 1) % 8]
+                    )
+            kwargs = {}
+            if level is RouteTraceLevel.IDS_WEIGHTS_MARGIN:
+                weights = torch.zeros(4, 2, 2, dtype=torch.float16)
+                margins = torch.zeros(4, 2, dtype=torch.float16)
+                weights[mask] = torch.tensor([0.625, 0.375], dtype=torch.float16)
+                margins[mask] = 0.125
+                kwargs = {"selected_weights": weights, "topk_margin": margins}
+            row.append(
+                RouteTraceV0(
+                    identity=identity,
+                    router_schema=schema,
+                    token_layout=RouteTokenLayoutV0(
+                        sample_id=rollout_route_sample_id(
+                            rollout_id, batch_index, group_index
+                        ),
+                        sequence_token_count=prompt_length + 4,
+                        prompt_token_count=prompt_length,
+                        token_offset=prompt_length,
+                        token_count=4,
+                        span_kind=TokenSpanKind.RESPONSE,
+                    ),
+                    level=level,
+                    topk_ids=pack_route_ids(ids, schema.num_experts),
+                    valid_mask=mask,
+                    **kwargs,
+                )
+            )
+        traces.append(row)
+    return traces
+
+
+def _raw_rollout(*, route_trace_batch=None):
+    prompts, prompt_mask, responses, response_mask = _rollout_tensors()
+    return RawRollout(
+        prompts=prompts,
+        prompt_mask=prompt_mask,
+        responses=responses,
+        response_mask=response_mask,
+        logprobs_old=torch.zeros_like(responses, dtype=torch.float32),
+        policy_version=3,
+        prompt_texts=["prompt-0", "prompt-1"],
+        response_texts=[["a", "b"], ["c", "d"]],
+        route_trace_batch=route_trace_batch,
+    )
+
+
+def _bind(raw, traces=None, *, rollout_id="rollout-17"):
+    return RolloutRouteTraceBatchV0.bind(
+        rollout_id=rollout_id,
+        policy_version=raw.policy_version,
+        prompts=raw.prompts,
+        prompt_mask=raw.prompt_mask,
+        responses=raw.responses,
+        response_mask=raw.response_mask,
+        logprobs_old=raw.logprobs_old,
+        traces=(_trace_grid(rollout_id=rollout_id) if traces is None else traces),
+    )
+
+
+def test_binding_is_deterministic_immutable_and_decodes_in_grid_order():
+    raw = _raw_rollout()
+    traces = _trace_grid(level=RouteTraceLevel.IDS_WEIGHTS_MARGIN)
+    bound = _bind(raw, traces)
+    repeated = _bind(raw, traces)
+
+    assert bound.schema_version == ROLLOUT_ROUTE_TRACE_SCHEMA_VERSION
+    assert bound.batch_size == 2
+    assert bound.group_size == 2
+    assert bound.policy_version == 3
+    assert bound.identity == traces[0][0].identity
+    assert bound.router_schema == traces[0][0].router_schema
+    assert bound.level is RouteTraceLevel.IDS_WEIGHTS_MARGIN
+    assert bound.artifact_digest == repeated.artifact_digest
+    assert type(bound.items) is tuple
+    assert type(bound.items[0]) is tuple
+    assert type(bound.items[0][0].payload) is bytes
+
+    original_id = int(traces[0][0].topk_ids[0, 0, 0].item())
+    traces[0][0].topk_ids[0, 0, 0] = 7
+    decoded = bound.decode_traces()
+    assert int(decoded[0][0].topk_ids[0, 0, 0].item()) == original_id
+    assert decoded[1][1].token_layout.sample_id == rollout_route_sample_id(
+        "rollout-17", 1, 1
+    )
+
+
+def test_binding_rejects_policy_grid_identity_level_and_sample_mismatches():
+    raw = _raw_rollout()
+    with pytest.raises(RolloutRouteTraceError, match="policy version"):
+        RolloutRouteTraceBatchV0.bind(
+            rollout_id="rollout",
+            policy_version=4,
+            prompts=raw.prompts,
+            prompt_mask=raw.prompt_mask,
+            responses=raw.responses,
+            response_mask=raw.response_mask,
+            logprobs_old=raw.logprobs_old,
+            traces=_trace_grid(),
+        )
+    with pytest.raises(RolloutRouteTraceError, match="B/G dimensions"):
+        _bind(raw, _trace_grid()[:1])
+
+    mixed_identity = _trace_grid()
+    other_identity = replace(mixed_identity[1][1].identity, model_revision="other")
+    mixed_identity[1][1] = replace(mixed_identity[1][1], identity=other_identity)
+    with pytest.raises(RolloutRouteTraceError, match="mix behavior identities"):
+        _bind(raw, mixed_identity)
+
+    mixed_level = _trace_grid()
+    mixed_level[1][1] = _trace_grid(level=RouteTraceLevel.IDS_WEIGHTS_MARGIN)[1][1]
+    with pytest.raises(RolloutRouteTraceError, match="mix trace levels"):
+        _bind(raw, mixed_level)
+
+    duplicate_sample = _trace_grid()
+    duplicate_sample[1][1] = replace(
+        duplicate_sample[1][1],
+        token_layout=replace(
+            duplicate_sample[1][1].token_layout,
+            sample_id=duplicate_sample[0][0].token_layout.sample_id,
+        ),
+    )
+    with pytest.raises(RolloutRouteTraceError, match="sample IDs must be unique"):
+        _bind(raw, duplicate_sample)
+
+    swapped = _trace_grid()
+    swapped[0][0], swapped[0][1] = swapped[0][1], swapped[0][0]
+    with pytest.raises(RolloutRouteTraceError, match="rollout grid position"):
+        _bind(raw, swapped)
+
+
+def test_validation_rejects_policy_prompt_response_and_mask_mutation():
+    raw = _raw_rollout()
+    bound = _bind(raw)
+    bound.validate_against(
+        policy_version=raw.policy_version,
+        prompts=raw.prompts,
+        prompt_mask=raw.prompt_mask,
+        responses=raw.responses,
+        response_mask=raw.response_mask,
+        logprobs_old=raw.logprobs_old,
+    )
+
+    with pytest.raises(RolloutRouteTraceError, match="policy version"):
+        bound.validate_against(
+            policy_version=4,
+            prompts=raw.prompts,
+            prompt_mask=raw.prompt_mask,
+            responses=raw.responses,
+            response_mask=raw.response_mask,
+            logprobs_old=raw.logprobs_old,
+        )
+    prompts = raw.prompts.clone()
+    prompts[0, -1] += 1
+    with pytest.raises(RolloutRouteTraceError, match="prompt tokens"):
+        bound.validate_against(
+            policy_version=3,
+            prompts=prompts,
+            prompt_mask=raw.prompt_mask,
+            responses=raw.responses,
+            response_mask=raw.response_mask,
+            logprobs_old=raw.logprobs_old,
+        )
+    responses = raw.responses.clone()
+    responses[0, 0, 0] += 1
+    with pytest.raises(RolloutRouteTraceError, match="response tokens"):
+        bound.validate_against(
+            policy_version=3,
+            prompts=raw.prompts,
+            prompt_mask=raw.prompt_mask,
+            responses=responses,
+            response_mask=raw.response_mask,
+            logprobs_old=raw.logprobs_old,
+        )
+    responses = raw.responses.clone()
+    response_mask = raw.response_mask.clone()
+    responses[0, 0, 1] = 0
+    response_mask[0, 0, 1] = False
+    with pytest.raises(RolloutRouteTraceError, match="response tokens"):
+        bound.validate_against(
+            policy_version=3,
+            prompts=raw.prompts,
+            prompt_mask=raw.prompt_mask,
+            responses=responses,
+            response_mask=response_mask,
+            logprobs_old=raw.logprobs_old,
+        )
+
+    logprobs_old = raw.logprobs_old.clone()
+    logprobs_old[0, 0, 0] = -1.0
+    with pytest.raises(RolloutRouteTraceError, match="behavior logprobs"):
+        bound.validate_against(
+            policy_version=3,
+            prompts=raw.prompts,
+            prompt_mask=raw.prompt_mask,
+            responses=raw.responses,
+            response_mask=raw.response_mask,
+            logprobs_old=logprobs_old,
+        )
+
+
+def test_binding_rejects_trace_boundaries_and_validity_mask_mismatch():
+    raw = _raw_rollout()
+    bad_boundary = _trace_grid()
+    layout = bad_boundary[0][0].token_layout
+    bad_boundary[0][0] = replace(
+        bad_boundary[0][0],
+        token_layout=replace(
+            layout,
+            sequence_token_count=layout.sequence_token_count + 1,
+            token_offset=layout.token_offset + 1,
+        ),
+    )
+    with pytest.raises(RolloutRouteTraceError, match="token boundaries"):
+        _bind(raw, bad_boundary)
+
+    bad_mask = _trace_grid()
+    trace = bad_mask[0][0]
+    mask = trace.valid_mask.clone()
+    mask[1] = False
+    ids = trace.topk_ids.clone()
+    ids[1] = 0
+    bad_mask[0][0] = replace(trace, topk_ids=ids, valid_mask=mask)
+    with pytest.raises(RolloutRouteTraceError, match="validity mask"):
+        _bind(raw, bad_mask)
+
+
+def test_binding_rejects_noncanonical_rollout_tensor_layout():
+    raw = _raw_rollout()
+    prompt_mask = raw.prompt_mask.clone()
+    prompt_mask[0] = torch.tensor([True, False, True])
+    with pytest.raises(RolloutRouteTraceError, match="left-padding"):
+        RolloutRouteTraceBatchV0.bind(
+            rollout_id="rollout",
+            policy_version=3,
+            prompts=raw.prompts,
+            prompt_mask=prompt_mask,
+            responses=raw.responses,
+            response_mask=raw.response_mask,
+            logprobs_old=raw.logprobs_old,
+            traces=_trace_grid(),
+        )
+
+    positive_logprob = raw.logprobs_old.clone()
+    positive_logprob[0, 0, 0] = 0.1
+    with pytest.raises(RolloutRouteTraceError, match="non-positive"):
+        RolloutRouteTraceBatchV0.bind(
+            rollout_id="rollout-17",
+            policy_version=3,
+            prompts=raw.prompts,
+            prompt_mask=raw.prompt_mask,
+            responses=raw.responses,
+            response_mask=raw.response_mask,
+            logprobs_old=positive_logprob,
+            traces=_trace_grid(),
+        )
+
+    padded_negative_zero = raw.logprobs_old.clone()
+    padded_negative_zero[0, 0, -1] = -0.0
+    with pytest.raises(RolloutRouteTraceError, match="canonical positive zero"):
+        RolloutRouteTraceBatchV0.bind(
+            rollout_id="rollout-17",
+            policy_version=3,
+            prompts=raw.prompts,
+            prompt_mask=raw.prompt_mask,
+            responses=raw.responses,
+            response_mask=raw.response_mask,
+            logprobs_old=padded_negative_zero,
+            traces=_trace_grid(),
+        )
+    responses = raw.responses.clone()
+    responses[0, 0, -1] = 99
+    with pytest.raises(RolloutRouteTraceError, match="padded response token"):
+        RolloutRouteTraceBatchV0.bind(
+            rollout_id="rollout",
+            policy_version=3,
+            prompts=raw.prompts,
+            prompt_mask=raw.prompt_mask,
+            responses=responses,
+            response_mask=raw.response_mask,
+            logprobs_old=raw.logprobs_old,
+            traces=_trace_grid(),
+        )
+
+
+def test_item_rejects_mutable_corrupt_or_mismatched_payload_headers():
+    item = RolloutRouteTraceItemV0.from_trace(_trace_grid()[0][0])
+    with pytest.raises(RolloutRouteTraceError, match="immutable bytes"):
+        replace(item, payload=bytearray(item.payload))
+    with pytest.raises(RolloutRouteTraceError, match="payload digest"):
+        replace(item, payload=item.payload[:-1] + bytes([item.payload[-1] ^ 1]))
+    with pytest.raises(RolloutRouteTraceError, match="identity header"):
+        replace(item, identity=replace(item.identity, model_revision="other"))
+
+
+def test_batch_constructor_rejects_unknown_versions_and_mutable_grids():
+    raw = _raw_rollout()
+    bound = _bind(raw)
+    with pytest.raises(RolloutRouteTraceError, match="unsupported.*schema version"):
+        replace(bound, schema_version=1)
+    with pytest.raises(RolloutRouteTraceError, match="non-empty tuple grid"):
+        replace(bound, items=list(bound.items))
+    with pytest.raises(RolloutRouteTraceError, match="non-empty tuple"):
+        replace(bound, items=(list(bound.items[0]), bound.items[1]))
+    with pytest.raises(RolloutRouteTraceError, match="RouteTraceV0"):
+        _bind(raw, [["bad", "bad"], ["bad", "bad"]])
+
+
+class _Generator:
+    def __init__(self, raw):
+        self.raw = raw
+        self.policy_version = raw.policy_version
+
+    def generate(self, _batch):
+        return self.raw
+
+    def with_policy_snapshot(self, inspect):
+        return inspect(self.policy_version)
+
+    def update_weights(self, policy_version):
+        self.policy_version = policy_version
+        return policy_version
+
+    def apply_weight_update(self, policy_version, update):
+        result = update()
+        self.policy_version = (
+            self.policy_version + 1 if policy_version is None else policy_version
+        )
+        return result
+
+
+class _Reward(BaseRewardModel):
+    def __init__(self, mutate=None):
+        self.mutate = mutate
+
+    def score(self, prompts, responses):
+        if self.mutate is not None:
+            self.mutate()
+        return torch.ones(len(prompts), len(responses[0]))
+
+
+def _runner(raw, *, mutate=None):
+    return RolloutRunner(
+        _Generator(raw), _Reward(mutate), rollout_interval=4, max_policy_lag=3
+    )
+
+
+def test_runner_preserves_and_validates_trace_binding_on_publish_and_reuse():
+    raw = _raw_rollout()
+    raw.route_trace_batch = _bind(raw)
+    runner = _runner(raw)
+
+    result, fresh = runner({"instruction": ["same"]})
+    assert fresh is True
+    assert result.route_trace_batch is raw.route_trace_batch
+    cached, fresh = runner({"instruction": ["same"]})
+    assert cached is result
+    assert fresh is False
+
+    cached.responses[0, 0, 0] += 1
+    with pytest.raises(RolloutRouteTraceError, match="response tokens"):
+        runner({"instruction": ["same"]})
+
+
+def test_runner_revalidates_trace_after_slow_scoring_before_cache_publish():
+    raw = _raw_rollout()
+    raw.route_trace_batch = _bind(raw)
+
+    def mutate_tokens():
+        raw.responses[0, 0, 0] += 1
+
+    runner = _runner(raw, mutate=mutate_tokens)
+    with pytest.raises(RolloutRouteTraceError, match="response tokens"):
+        runner({"instruction": ["same"]})
+    assert runner._cache is None
+
+
+def test_runner_rejects_wrong_binding_type_but_none_keeps_default_path():
+    plain = _raw_rollout()
+    result, fresh = _runner(plain)({"instruction": ["plain"]})
+    assert fresh is True
+    assert result.route_trace_batch is None
+
+    invalid = _raw_rollout(route_trace_batch="not-a-route-trace-batch")
+    with pytest.raises(RolloutRouteTraceError, match="RolloutRouteTraceBatchV0"):
+        _runner(invalid)({"instruction": ["invalid"]})
+
+
+def test_manifest_is_payload_free_and_digest_binds_rollout_order():
+    raw = _raw_rollout()
+    first = _bind(raw, rollout_id="rollout-a")
+    second = _bind(raw, rollout_id="rollout-b")
+
+    manifest = first.manifest()
+    assert "payload" not in manifest["items"][0][0]
+    assert manifest["payload_nbytes"] == first.payload_nbytes
+    assert manifest["items"][0][0]["artifact_digest"]
+    assert first.artifact_digest != second.artifact_digest

--- a/tests/trainer/test_rollout_route_trace.py
+++ b/tests/trainer/test_rollout_route_trace.py
@@ -1,9 +1,11 @@
 """Tests for immutable RouteTraceV0 bindings at rollout cache boundaries."""
 
+import json
 from dataclasses import replace
 
 import pytest
 import torch
+import torch.distributed as dist
 
 from astrai.moe import (
     PaddingLayout,
@@ -17,6 +19,7 @@ from astrai.moe import (
     canonical_json_digest,
     pack_route_ids,
 )
+from astrai.parallel import get_rank, get_world_size, spawn_parallel_fn
 from astrai.trainer.rollout import (
     BaseRewardModel,
     RawRollout,
@@ -28,6 +31,12 @@ from astrai.trainer.route_trace import (
     RolloutRouteTraceError,
     RolloutRouteTraceItemV0,
     rollout_route_sample_id,
+)
+from astrai.trainer.route_trace_transport import (
+    ROLLOUT_ROUTE_TRACE_SHARD_SCHEMA_VERSION,
+    RolloutRouteTraceShardCodecV0,
+    RolloutRouteTraceShardManifestV0,
+    RolloutRouteTraceTransportV0,
 )
 
 
@@ -375,6 +384,16 @@ def test_binding_rejects_noncanonical_rollout_tensor_layout():
 
 def test_item_rejects_mutable_corrupt_or_mismatched_payload_headers():
     item = RolloutRouteTraceItemV0.from_trace(_trace_grid()[0][0])
+    restored = RolloutRouteTraceItemV0.from_payload(
+        item.payload,
+        max_serialized_bytes=len(item.payload),
+    )
+    assert restored == item
+    with pytest.raises(RolloutRouteTraceError, match="size limit"):
+        RolloutRouteTraceItemV0.from_payload(
+            item.payload,
+            max_serialized_bytes=len(item.payload) - 1,
+        )
     with pytest.raises(RolloutRouteTraceError, match="immutable bytes"):
         replace(item, payload=bytearray(item.payload))
     with pytest.raises(RolloutRouteTraceError, match="payload digest"):
@@ -486,3 +505,183 @@ def test_manifest_is_payload_free_and_digest_binds_rollout_order():
     assert manifest["payload_nbytes"] == first.payload_nbytes
     assert manifest["items"][0][0]["artifact_digest"]
     assert first.artifact_digest != second.artifact_digest
+
+
+def test_sharded_transport_is_deterministic_bounded_and_lossless():
+    raw = _raw_rollout()
+    bound = _bind(raw, _trace_grid(level=RouteTraceLevel.IDS_WEIGHTS_MARGIN))
+
+    transport = RolloutRouteTraceTransportV0.from_batch(
+        bound,
+        max_shard_bytes=1024 * 1024,
+        max_items_per_shard=2,
+    )
+    repeated = RolloutRouteTraceTransportV0.from_batch(
+        bound,
+        max_shard_bytes=1024 * 1024,
+        max_items_per_shard=2,
+    )
+
+    assert len(transport.shard_payloads) == 2
+    assert transport.shard_payloads == repeated.shard_payloads
+    assert transport.manifest == repeated.manifest
+    assert transport.manifest.schema_version == ROLLOUT_ROUTE_TRACE_SHARD_SCHEMA_VERSION
+    assert all(
+        descriptor.encoded_nbytes <= 1024 * 1024
+        for descriptor in transport.manifest.shards
+    )
+    restored_manifest = RolloutRouteTraceShardManifestV0.loads(
+        transport.manifest.dumps()
+    )
+    assert restored_manifest == transport.manifest
+    assert restored_manifest.artifact_digest == transport.manifest.artifact_digest
+
+    restored = restored_manifest.assemble(transport.shard_payloads)
+    assert restored.artifact_digest == bound.artifact_digest
+    assert restored.payload_nbytes == bound.payload_nbytes
+    assert tuple(item.payload for row in restored.items for item in row) == tuple(
+        item.payload for row in bound.items for item in row
+    )
+    restored.validate_against(
+        policy_version=raw.policy_version,
+        prompts=raw.prompts,
+        prompt_mask=raw.prompt_mask,
+        responses=raw.responses,
+        response_mask=raw.response_mask,
+        logprobs_old=raw.logprobs_old,
+    )
+
+
+def test_sharded_transport_fails_closed_on_missing_reordered_or_corrupt_frames():
+    raw = _raw_rollout()
+    bound = _bind(raw)
+    transport = RolloutRouteTraceTransportV0.from_batch(
+        bound,
+        max_items_per_shard=1,
+    )
+    manifest = transport.manifest
+
+    with pytest.raises(RolloutRouteTraceError, match="count"):
+        manifest.assemble(transport.shard_payloads[:-1])
+    reordered = list(transport.shard_payloads)
+    reordered[0], reordered[1] = reordered[1], reordered[0]
+    with pytest.raises(RolloutRouteTraceError, match="size|digest"):
+        manifest.assemble(reordered)
+
+    corrupt = bytearray(transport.shard_payloads[0])
+    corrupt[-1] ^= 1
+    with pytest.raises(RolloutRouteTraceError, match="digest"):
+        manifest.verify_shard(0, corrupt)
+    with pytest.raises(RolloutRouteTraceError, match="immutable bytes"):
+        replace(transport, shard_payloads=(corrupt, *transport.shard_payloads[1:]))
+
+    foreign = RolloutRouteTraceTransportV0.from_batch(
+        _bind(raw, rollout_id="rollout-other"),
+        max_items_per_shard=1,
+    )
+    with pytest.raises(RolloutRouteTraceError, match="size|digest"):
+        manifest.verify_shard(0, foreign.shard_payloads[0])
+
+
+def test_shard_manifest_and_frame_decoders_reject_schema_and_size_ambiguity():
+    transport = RolloutRouteTraceTransportV0.from_batch(
+        _bind(_raw_rollout()),
+        max_items_per_shard=1,
+    )
+    manifest_payload = transport.manifest.dumps()
+    manifest = json.loads(manifest_payload)
+
+    unknown = dict(manifest)
+    unknown["future"] = True
+    with pytest.raises(RolloutRouteTraceError, match="unknown"):
+        RolloutRouteTraceShardManifestV0.loads(
+            json.dumps(unknown, sort_keys=True, separators=(",", ":")).encode()
+        )
+    future = dict(manifest)
+    future["schema_version"] = 1
+    with pytest.raises(RolloutRouteTraceError, match="schema_version"):
+        RolloutRouteTraceShardManifestV0.loads(
+            json.dumps(future, sort_keys=True, separators=(",", ":")).encode()
+        )
+    with pytest.raises(RolloutRouteTraceError, match="canonical JSON"):
+        RolloutRouteTraceShardManifestV0.loads(
+            json.dumps(manifest, sort_keys=True, indent=2).encode()
+        )
+    with pytest.raises(RolloutRouteTraceError, match="size limit"):
+        RolloutRouteTraceShardManifestV0.loads(
+            manifest_payload,
+            max_manifest_bytes=len(manifest_payload) - 1,
+        )
+    with pytest.raises(RolloutRouteTraceError, match="max_shard_bytes"):
+        RolloutRouteTraceShardManifestV0.loads(
+            manifest_payload,
+            max_shard_bytes=transport.manifest.shards[0].encoded_nbytes - 1,
+        )
+    with pytest.raises(RolloutRouteTraceError, match="max_transport_bytes"):
+        RolloutRouteTraceShardManifestV0.loads(
+            manifest_payload,
+            max_transport_bytes=(
+                len(manifest_payload) + transport.manifest.encoded_nbytes - 1
+            ),
+        )
+
+    frame = transport.shard_payloads[0]
+    with pytest.raises(RolloutRouteTraceError, match="size limit"):
+        RolloutRouteTraceShardCodecV0.loads(
+            frame,
+            max_shard_bytes=len(frame) - 1,
+        )
+    with pytest.raises(RolloutRouteTraceError, match="magic"):
+        RolloutRouteTraceShardCodecV0.loads(b"badmagic" + frame[8:])
+    with pytest.raises(RolloutRouteTraceError, match="trailing bytes"):
+        RolloutRouteTraceShardCodecV0.loads(
+            frame + b"x",
+            max_shard_bytes=len(frame) + 1,
+        )
+
+
+def test_sharded_transport_rejects_an_item_larger_than_the_shard_cap():
+    transport = RolloutRouteTraceTransportV0.from_batch(
+        _bind(_raw_rollout()),
+        max_items_per_shard=1,
+    )
+    smallest_frame = min(
+        descriptor.encoded_nbytes for descriptor in transport.manifest.shards
+    )
+    with pytest.raises(RolloutRouteTraceError, match="one route trace item"):
+        RolloutRouteTraceTransportV0.from_batch(
+            _bind(_raw_rollout()),
+            max_shard_bytes=smallest_frame - 1,
+            max_items_per_shard=1,
+        )
+
+
+def _distributed_route_shard_worker():
+    rank = get_rank()
+    world_size = get_world_size()
+    transport = RolloutRouteTraceTransportV0.from_batch(
+        _bind(_raw_rollout()),
+        max_items_per_shard=1,
+    )
+    local = transport.payloads_for_rank(rank, world_size)
+    local_indices = tuple(index for index, _ in local)
+    assert local_indices == transport.manifest.shard_indices_for_rank(rank, world_size)
+    for index, payload in local:
+        shard = transport.manifest.verify_shard(index, payload)
+        assert shard.shard_index == index
+
+    gathered = [None for _ in range(world_size)]
+    dist.all_gather_object(gathered, local_indices)
+    flattened = [index for indices in gathered for index in indices]
+    assert sorted(flattened) == list(range(len(transport.shard_payloads)))
+    assert len(flattened) == len(set(flattened))
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_shard_assignment_is_complete_on_real_gloo_groups(world_size):
+    spawn_parallel_fn(
+        _distributed_route_shard_worker,
+        world_size=world_size,
+        backend="gloo",
+        device_type="cpu",
+    )

--- a/tests/trainer/test_rollout_route_trace_benchmark.py
+++ b/tests/trainer/test_rollout_route_trace_benchmark.py
@@ -1,0 +1,72 @@
+"""Tests for the rollout route-trace binding microbenchmark."""
+
+import pytest
+import torch
+
+from astrai.moe import RouteTraceLevel
+from astrai.trainer.route_trace import rollout_route_sample_id
+from scripts.benchmark_rollout_route_binding import (
+    build_rollout_inputs,
+    run_benchmark,
+)
+
+
+@pytest.mark.parametrize("level", list(RouteTraceLevel))
+def test_binding_benchmark_reports_explicit_scope_bytes_and_latency(level):
+    report = run_benchmark(
+        batch_size=2,
+        group_size=2,
+        prompt_tokens=3,
+        response_tokens=4,
+        layers=2,
+        top_k=2,
+        num_experts=8,
+        level=level,
+        device=torch.device("cpu"),
+        warmups=0,
+        bind_repeats=1,
+        validate_repeats=2,
+    )
+
+    assert report["schema_version"] == 1
+    assert report["benchmark"] == "astrai-rollout-route-trace-binding-v0"
+    assert report["parameters"]["level"] == level.value
+    assert report["bytes"]["trace_payloads"] > 0
+    assert report["bytes"]["identity_manifest"] > 0
+    assert report["latency_us"]["bind_median"] > 0
+    assert report["latency_us"]["validate_median"] > 0
+    assert len(report["artifact_digest"]) == 64
+
+
+def test_binding_benchmark_uses_coordinate_derived_sample_ids():
+    tensors, traces = build_rollout_inputs(
+        batch_size=2,
+        group_size=2,
+        prompt_tokens=3,
+        response_tokens=4,
+        layers=2,
+        top_k=2,
+        num_experts=8,
+        level=RouteTraceLevel.IDS,
+        device=torch.device("cpu"),
+    )
+
+    assert tensors["responses"].shape == (2, 2, 4)
+    assert traces[1][1].token_layout.sample_id == rollout_route_sample_id(
+        "rollout-route-binding-benchmark", 1, 1
+    )
+
+
+def test_binding_benchmark_rejects_invalid_geometry():
+    with pytest.raises(ValueError, match="dimensions"):
+        build_rollout_inputs(
+            batch_size=1,
+            group_size=1,
+            prompt_tokens=1,
+            response_tokens=1,
+            layers=1,
+            top_k=3,
+            num_experts=2,
+            level=RouteTraceLevel.IDS,
+            device=torch.device("cpu"),
+        )

--- a/tests/trainer/test_rollout_route_transport_benchmark.py
+++ b/tests/trainer/test_rollout_route_transport_benchmark.py
@@ -1,0 +1,53 @@
+"""Tests for the rollout route shard transport microbenchmark."""
+
+import pytest
+
+from astrai.moe import RouteTraceLevel
+from scripts.benchmark_rollout_route_transport import run_benchmark
+
+
+def test_transport_benchmark_reports_lossless_bounded_shards():
+    report = run_benchmark(
+        batch_size=2,
+        group_size=2,
+        prompt_tokens=2,
+        response_tokens=4,
+        layers=2,
+        top_k=2,
+        num_experts=8,
+        level=RouteTraceLevel.IDS,
+        max_shard_bytes=1024 * 1024,
+        max_items_per_shard=1,
+        warmups=0,
+        repeats=1,
+    )
+
+    assert report["schema_version"] == 1
+    assert report["shard_count"] == 4
+    assert report["bytes"]["largest_shard"] <= 1024 * 1024
+    assert report["bytes"]["transport_total"] > report["bytes"]["trace_payloads"]
+    assert report["latency_us"]["build"]["median"] > 0
+    assert report["latency_us"]["verify_all"]["median"] > 0
+    assert report["latency_us"]["assemble"]["median"] > 0
+    assert (
+        sum(report["rank_assignment"]["2"]["per_rank_encoded_nbytes"])
+        == report["bytes"]["encoded_shards"]
+    )
+
+
+def test_transport_benchmark_rejects_invalid_geometry():
+    with pytest.raises(ValueError, match="top_k"):
+        run_benchmark(
+            batch_size=1,
+            group_size=1,
+            prompt_tokens=1,
+            response_tokens=1,
+            layers=1,
+            top_k=3,
+            num_experts=2,
+            level=RouteTraceLevel.IDS,
+            max_shard_bytes=1024,
+            max_items_per_shard=1,
+            warmups=0,
+            repeats=1,
+        )


### PR DESCRIPTION
## Summary

Depends on #63 (rollout identity), transitively #64 (RouteTraceV0).

### Exact-head confirmation (2026-09-05)

`python -m pytest -p no:cacheprovider -q tests/` at
`953c7714ecb5ee3526193bf5fcf2112e74514777`: **757 passed, 57 skipped in 63.65s**, container exit 0.
This final run retained its log independently of SSH connectivity. It used
the CPU-only environment described below; GPU tests remain skipped.

Add deterministic bounded byte shards for rollout-bound RouteTrace artifacts,
authenticate shards/items, validate assigned subsets, and reconstruct the exact
batch. Bound manifest/shard/item/total sizes and reject malformed, noncanonical,
corrupted, missing/reordered, cross-batch and trailing data.

Rank assignment is generic round-robin. Actual distributed tests use 2 or 4
ranks only. No network selection, model capture, replay, admission policy or
default training behavior changes are included.

## Revision and dependency

- Base: main `e1e533c88e74efab4f379d6ccbc830c2b3e698e2`.
- Head/review increment: `953c7714ecb5ee3526193bf5fcf2112e74514777`.
- Depends on rollout identity `bea9ecf71f623d7b78aa2baed59646be871af19c`
  (`codex/draft-rollout-route-identity`), which depends on RouteTraceV0.
  Review the increment after those dependencies; main-based diff includes them.
- No open PR provides this bounded route transport framing/verification layer.

## Validation

- `python -m pytest -p no:cacheprovider -q tests/trainer/test_rollout_route_trace.py tests/trainer/test_rollout_route_transport_benchmark.py`: 19 passed at `7d54a9ac100341febf90c2bc5b4d1020005234e4`, including CPU Gloo 2/4 ranks.
- Latest main replay has an identical Python tree; changed-file Ruff 0.14.7
  import/format and `git diff --check` passed.
- Original pre-rebase full suite: 747 passed, 50 skipped (historical only).
- Fresh exact-head full-suite confirmation is recorded below when available.
  Initial collection lacked httpx2; a retry lost SSH before returning a final
  result. Neither is counted as a successful full run.

CPU image `astrai-test:cu128`, Python 3.12.3, torch 2.11.0+cu128, pytest 8.3.5.
No GPUs exposed; httpx2 2.12.0 added only in the disposable test container.

## Historical benchmark (pre-rebase)

CPU framing only, L20 host: IDs B=8 G=8 P=512 R=1024 L=40 K=22 E=512,
2 MiB / 8-item caps: 115,434,944 -> 115,472,769 bytes (+0.032767%), 64 shards;
build median 244,604 us, verify-all 1,153,011 us, reconstruct 1,143,879 us.
These numbers exclude actual networking and training throughput.

## Review status

AI assistance was used. Keep Draft for human line-by-line review, dependency
review and CI; no fresh GPU or end-to-end performance claim is made.
