### PR TITLE
feat: validate MoE checkpoint recompute routes

### DIFF
--- a/astrai/config/train_config.py
+++ b/astrai/config/train_config.py
@@ -19,6 +19,7 @@ DP_MODES = frozenset({"none", "ddp", "fsdp"})
 BACKENDS = frozenset({"nccl", "gloo"})
 START_METHODS = frozenset({"spawn", "fork", "forkserver"})
 _COMPILE_MODES = frozenset({"default", "reduce-overhead", "max-autotune"})
+_ROUTE_RECOMPUTE_VALIDATION_MODES = frozenset({"off", "record", "error"})
 
 
 @dataclass(config=ConfigDict(arbitrary_types_allowed=True))
@@ -41,6 +42,7 @@ class TrainConfig(BaseConfig):
         grad_accum_steps (int): Number of iterations between optimizer steps. Defaults to 1.
         max_grad_norm (Optional[float]): Maximum gradient norm. None disables clipping. Defaults to 1.0.
         gradient_checkpointing_modules (List[type]): Module types to enable activation checkpointing for. Defaults to [].
+        gradient_checkpointing_route_validation (str): Optional forward/recompute MoE route diagnostic mode: off, record, or error. Defaults to off.
         compile_mode (Optional[str]): torch.compile mode: 'default', 'reduce-overhead', 'max-autotune', or None. Defaults to None.
         start_epoch (int): Start epoch for training. Defaults to 0.
         start_samples (int): Start samples count (per rank). Superseded by checkpoint consumed_samples. Defaults to 0.
@@ -93,6 +95,7 @@ class TrainConfig(BaseConfig):
     grad_accum_steps: int = 1
     max_grad_norm: Optional[float] = 1.0
     gradient_checkpointing_modules: List[type] = field(default_factory=list)
+    gradient_checkpointing_route_validation: str = "off"
     compile_mode: Optional[str] = None
 
     start_epoch: int = 0
@@ -205,6 +208,15 @@ class TrainConfig(BaseConfig):
             )
         return v
 
+    @field_validator("gradient_checkpointing_route_validation")
+    def _validate_route_recompute_validation(cls, v: str) -> str:
+        if v not in _ROUTE_RECOMPUTE_VALIDATION_MODES:
+            raise ValueError(
+                "gradient_checkpointing_route_validation must be one of "
+                f"{sorted(_ROUTE_RECOMPUTE_VALIDATION_MODES)}, got {v!r}"
+            )
+        return v
+
     @field_validator(
         "n_epoch",
         "batch_per_device",
@@ -256,6 +268,21 @@ class TrainConfig(BaseConfig):
         if v is not None and not 0 < v < 1:
             raise ValueError(f"val_split must be in (0, 1) or None, got {v}")
         return v
+
+    @model_validator(mode="after")
+    def _validate_route_recompute_configuration(self) -> "TrainConfig":
+        if self.gradient_checkpointing_route_validation != "off":
+            if not self.gradient_checkpointing_modules:
+                raise ValueError(
+                    "gradient_checkpointing_route_validation requires "
+                    "gradient_checkpointing_modules"
+                )
+            if self.compile_mode is not None:
+                raise ValueError(
+                    "gradient checkpoint route validation is not supported with "
+                    "torch.compile"
+                )
+        return self
 
     @model_validator(mode="after")
     def _validate_online_strategy(self) -> "TrainConfig":

--- a/astrai/moe/__init__.py
+++ b/astrai/moe/__init__.py
@@ -1,0 +1,49 @@
+"""Semantic contracts and diagnostics for mixture-of-experts routing."""
+
+from astrai.moe.route_metrics import (
+    RouteAlignmentMetricsV0,
+    compare_route_traces,
+    compute_topk_margin,
+)
+from astrai.moe.route_trace import (
+    ROUTE_TRACE_SCHEMA_VERSION,
+    PaddingLayout,
+    RouteIdentityV0,
+    RouterSchemaV0,
+    RouteTokenLayoutV0,
+    RouteTraceCodecV0,
+    RouteTraceLevel,
+    RouteTraceV0,
+    RouteTraceValidationError,
+    SelectedWeightSemantics,
+    TokenSpanKind,
+    canonical_json_digest,
+    pack_route_ids,
+    recommended_route_id_dtype,
+    require_compatible_route_trace,
+    require_semantically_aligned_traces,
+    validate_route_trace,
+)
+
+__all__ = [
+    "ROUTE_TRACE_SCHEMA_VERSION",
+    "PaddingLayout",
+    "RouteAlignmentMetricsV0",
+    "RouteIdentityV0",
+    "RouteTokenLayoutV0",
+    "RouteTraceCodecV0",
+    "RouteTraceLevel",
+    "RouteTraceV0",
+    "RouteTraceValidationError",
+    "RouterSchemaV0",
+    "SelectedWeightSemantics",
+    "TokenSpanKind",
+    "canonical_json_digest",
+    "compare_route_traces",
+    "compute_topk_margin",
+    "pack_route_ids",
+    "recommended_route_id_dtype",
+    "require_compatible_route_trace",
+    "require_semantically_aligned_traces",
+    "validate_route_trace",
+]

--- a/astrai/moe/__init__.py
+++ b/astrai/moe/__init__.py
@@ -1,5 +1,16 @@
 """Semantic contracts and diagnostics for mixture-of-experts routing."""
 
+from astrai.moe.recompute import (
+    ROUTE_RECOMPUTE_SCHEMA_VERSION,
+    RecomputeRouteMismatchError,
+    RecomputeRoutePairReportV0,
+    RecomputeRouteValidationError,
+    RouteCheckpointPairV0,
+    RouteRecomputeDiagnosticsV0,
+    RouteRecomputeSummaryV0,
+    compare_recompute_routes,
+    synchronize_route_recompute_summary,
+)
 from astrai.moe.route_metrics import (
     RouteAlignmentMetricsV0,
     compare_route_traces,
@@ -26,24 +37,33 @@ from astrai.moe.route_trace import (
 )
 
 __all__ = [
+    "ROUTE_RECOMPUTE_SCHEMA_VERSION",
     "ROUTE_TRACE_SCHEMA_VERSION",
     "PaddingLayout",
     "RouteAlignmentMetricsV0",
+    "RouteCheckpointPairV0",
     "RouteIdentityV0",
     "RouteTokenLayoutV0",
     "RouteTraceCodecV0",
     "RouteTraceLevel",
     "RouteTraceV0",
     "RouteTraceValidationError",
+    "RouteRecomputeDiagnosticsV0",
+    "RouteRecomputeSummaryV0",
     "RouterSchemaV0",
     "SelectedWeightSemantics",
     "TokenSpanKind",
     "canonical_json_digest",
+    "compare_recompute_routes",
     "compare_route_traces",
     "compute_topk_margin",
     "pack_route_ids",
     "recommended_route_id_dtype",
+    "RecomputeRouteMismatchError",
+    "RecomputeRoutePairReportV0",
+    "RecomputeRouteValidationError",
     "require_compatible_route_trace",
     "require_semantically_aligned_traces",
     "validate_route_trace",
+    "synchronize_route_recompute_summary",
 ]

--- a/astrai/moe/recompute.py
+++ b/astrai/moe/recompute.py
@@ -1,0 +1,659 @@
+"""Diagnostics for MoE routes across activation-checkpoint recomputation.
+
+The helpers in this module observe route IDs that a checkpointed module already
+returns. They do not choose experts, alter dispatch, or replay a route. Runtime
+integration can therefore remain opt-in while still detecting when backward
+recomputation followed a different sparse path from the original forward.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sys
+import threading
+from collections.abc import Mapping, Sequence
+from contextlib import AbstractContextManager, contextmanager
+from dataclasses import dataclass
+from typing import Any, Iterator
+
+import torch
+import torch.distributed as dist
+from torch import Tensor
+
+from astrai.moe.route_trace import canonical_json_digest
+
+ROUTE_RECOMPUTE_SCHEMA_VERSION = 0
+
+_SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
+_INTEGER_DTYPES = (
+    torch.int8,
+    torch.int16,
+    torch.int32,
+    torch.int64,
+    torch.uint8,
+    torch.uint16,
+    torch.uint32,
+)
+_SUMMARY_COUNT_FIELDS = (
+    "forward_pair_count",
+    "completed_forward_pair_count",
+    "compared_pair_count",
+    "exact_pair_count",
+    "mismatch_pair_count",
+    "invalid_pair_count",
+    "compared_layer_count",
+    "compared_token_count",
+    "compared_slot_count",
+    "mismatch_layer_count",
+    "mismatch_token_count",
+    "mismatch_slot_count",
+    "rank_observation_inconsistent",
+)
+
+__all__ = [
+    "ROUTE_RECOMPUTE_SCHEMA_VERSION",
+    "RecomputeRouteMismatchError",
+    "RecomputeRoutePairReportV0",
+    "RecomputeRouteValidationError",
+    "RouteCheckpointPairV0",
+    "RouteRecomputeDiagnosticsV0",
+    "RouteRecomputeSummaryV0",
+    "compare_recompute_routes",
+    "synchronize_route_recompute_summary",
+]
+
+
+class RecomputeRouteValidationError(ValueError):
+    """Route observations cannot be compared under the declared contract."""
+
+
+class RecomputeRouteMismatchError(RuntimeError):
+    """Checkpoint recomputation produced an unsafe route diagnostic."""
+
+
+def _require_non_negative_int(name: str, value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise RecomputeRouteValidationError(f"{name} must be a non-negative integer")
+    return value
+
+
+def _require_digest(name: str, value: Any) -> str:
+    if not isinstance(value, str) or _SHA256_PATTERN.fullmatch(value) is None:
+        raise RecomputeRouteValidationError(
+            f"{name} must be a lowercase SHA-256 digest"
+        )
+    return value
+
+
+def _normalize_route_tensor(name: str, tensor: Tensor) -> Tensor:
+    if not isinstance(tensor, Tensor):
+        raise RecomputeRouteValidationError(f"{name} must be a torch.Tensor")
+    if tensor.layout is not torch.strided or tensor.device.type == "meta":
+        raise RecomputeRouteValidationError(
+            f"{name} must be a materialized strided tensor"
+        )
+    if tensor.dtype not in _INTEGER_DTYPES:
+        raise RecomputeRouteValidationError(f"{name} must use an integer dtype")
+    if tensor.ndim < 2 or tensor.shape[-1] < 1:
+        raise RecomputeRouteValidationError(
+            f"{name} must have token dimensions followed by a positive top-k axis"
+        )
+    if sys.byteorder != "little":
+        raise RecomputeRouteValidationError(
+            "route recompute diagnostics require a little-endian host"
+        )
+
+    normalized = tensor.detach().to(dtype=torch.int64).contiguous().cpu().clone()
+    if normalized.numel() and int(normalized.min().item()) < 0:
+        raise RecomputeRouteValidationError(f"{name} contains a negative expert ID")
+    rows = normalized.reshape(-1, normalized.shape[-1])
+    if rows.shape[-1] > 1 and rows.numel():
+        ordered = rows.sort(dim=-1).values
+        if bool((ordered[:, 1:] == ordered[:, :-1]).any().item()):
+            raise RecomputeRouteValidationError(
+                f"{name} contains duplicate experts in a top-k row"
+            )
+    return normalized
+
+
+def _normalize_route_layers(
+    value: Tensor | Sequence[Tensor], *, label: str
+) -> tuple[Tensor, ...]:
+    if isinstance(value, Tensor):
+        layers = (value,)
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        layers = tuple(value)
+    else:
+        raise RecomputeRouteValidationError(
+            f"{label} routes must be a tensor or a sequence of tensors"
+        )
+    if not layers:
+        raise RecomputeRouteValidationError(
+            f"{label} routes must contain at least one routed layer"
+        )
+    return tuple(
+        _normalize_route_tensor(f"{label} routes[{index}]", layer)
+        for index, layer in enumerate(layers)
+    )
+
+
+def _layer_descriptor(tensor: Tensor) -> dict[str, Any]:
+    raw = tensor.view(torch.uint8).reshape(-1).numpy().tobytes()
+    return {
+        "dtype": "int64",
+        "payload_sha256": hashlib.sha256(raw).hexdigest(),
+        "shape": list(tensor.shape),
+    }
+
+
+def _route_layers_digest(layers: tuple[Tensor, ...]) -> str:
+    return canonical_json_digest(
+        {
+            "layers": [_layer_descriptor(layer) for layer in layers],
+            "schema_version": ROUTE_RECOMPUTE_SCHEMA_VERSION,
+        }
+    )
+
+
+@dataclass(frozen=True)
+class RecomputeRoutePairReportV0:
+    """Exact route comparison for one checkpointed module invocation."""
+
+    forward_route_hash: str
+    recompute_route_hash: str
+    layer_count: int
+    token_count: int
+    slot_count: int
+    mismatch_layer_count: int
+    mismatch_token_count: int
+    mismatch_slot_count: int
+    schema_version: int = ROUTE_RECOMPUTE_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != ROUTE_RECOMPUTE_SCHEMA_VERSION:
+            raise RecomputeRouteValidationError(
+                f"unsupported route recompute schema version {self.schema_version}"
+            )
+        _require_digest("forward_route_hash", self.forward_route_hash)
+        _require_digest("recompute_route_hash", self.recompute_route_hash)
+        for name in (
+            "layer_count",
+            "token_count",
+            "slot_count",
+            "mismatch_layer_count",
+            "mismatch_token_count",
+            "mismatch_slot_count",
+        ):
+            _require_non_negative_int(name, getattr(self, name))
+        if self.layer_count < 1:
+            raise RecomputeRouteValidationError("layer_count must be positive")
+        if self.mismatch_layer_count > self.layer_count:
+            raise RecomputeRouteValidationError(
+                "mismatch_layer_count exceeds layer_count"
+            )
+        if self.mismatch_token_count > self.token_count:
+            raise RecomputeRouteValidationError(
+                "mismatch_token_count exceeds token_count"
+            )
+        if self.mismatch_slot_count > self.slot_count:
+            raise RecomputeRouteValidationError(
+                "mismatch_slot_count exceeds slot_count"
+            )
+        no_mismatch = not (
+            self.mismatch_layer_count
+            or self.mismatch_token_count
+            or self.mismatch_slot_count
+        )
+        if no_mismatch != (self.forward_route_hash == self.recompute_route_hash):
+            raise RecomputeRouteValidationError(
+                "route hashes and mismatch counts disagree"
+            )
+
+    @property
+    def exact_match(self) -> bool:
+        return self.mismatch_slot_count == 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "exact_match": self.exact_match,
+            "forward_route_hash": self.forward_route_hash,
+            "layer_count": self.layer_count,
+            "mismatch_layer_count": self.mismatch_layer_count,
+            "mismatch_slot_count": self.mismatch_slot_count,
+            "mismatch_token_count": self.mismatch_token_count,
+            "recompute_route_hash": self.recompute_route_hash,
+            "schema_version": self.schema_version,
+            "slot_count": self.slot_count,
+            "token_count": self.token_count,
+        }
+
+
+def _compare_normalized_routes(
+    forward_layers: tuple[Tensor, ...], recompute_layers: tuple[Tensor, ...]
+) -> RecomputeRoutePairReportV0:
+    if len(forward_layers) != len(recompute_layers):
+        raise RecomputeRouteValidationError(
+            "forward and recompute routed-layer counts differ"
+        )
+
+    mismatch_layer_count = 0
+    mismatch_token_count = 0
+    mismatch_slot_count = 0
+    token_count = 0
+    slot_count = 0
+    for index, (forward, recompute) in enumerate(zip(forward_layers, recompute_layers)):
+        if forward.shape != recompute.shape:
+            raise RecomputeRouteValidationError(
+                f"forward and recompute route shapes differ at layer {index}"
+            )
+        forward_rows = forward.reshape(-1, forward.shape[-1])
+        recompute_rows = recompute.reshape(-1, recompute.shape[-1])
+        slot_mismatch = forward_rows != recompute_rows
+        token_mismatch = slot_mismatch.any(dim=-1)
+        layer_mismatch = bool(token_mismatch.any().item())
+        mismatch_layer_count += int(layer_mismatch)
+        mismatch_token_count += int(token_mismatch.sum().item())
+        mismatch_slot_count += int(slot_mismatch.sum().item())
+        token_count += forward_rows.shape[0]
+        slot_count += forward.numel()
+
+    return RecomputeRoutePairReportV0(
+        forward_route_hash=_route_layers_digest(forward_layers),
+        recompute_route_hash=_route_layers_digest(recompute_layers),
+        layer_count=len(forward_layers),
+        token_count=token_count,
+        slot_count=slot_count,
+        mismatch_layer_count=mismatch_layer_count,
+        mismatch_token_count=mismatch_token_count,
+        mismatch_slot_count=mismatch_slot_count,
+    )
+
+
+def compare_recompute_routes(
+    forward_routes: Tensor | Sequence[Tensor],
+    recompute_routes: Tensor | Sequence[Tensor],
+) -> RecomputeRoutePairReportV0:
+    """Compare ordered top-k IDs from forward and checkpoint recomputation."""
+    forward_layers = _normalize_route_layers(forward_routes, label="forward")
+    recompute_layers = _normalize_route_layers(recompute_routes, label="recompute")
+    return _compare_normalized_routes(forward_layers, recompute_layers)
+
+
+@dataclass(frozen=True)
+class RouteRecomputeSummaryV0:
+    """Bounded counters for one batch or an exact merge across ranks."""
+
+    forward_pair_count: int = 0
+    completed_forward_pair_count: int = 0
+    compared_pair_count: int = 0
+    exact_pair_count: int = 0
+    mismatch_pair_count: int = 0
+    invalid_pair_count: int = 0
+    compared_layer_count: int = 0
+    compared_token_count: int = 0
+    compared_slot_count: int = 0
+    mismatch_layer_count: int = 0
+    mismatch_token_count: int = 0
+    mismatch_slot_count: int = 0
+    rank_observation_inconsistent: int = 0
+    schema_version: int = ROUTE_RECOMPUTE_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != ROUTE_RECOMPUTE_SCHEMA_VERSION:
+            raise RecomputeRouteValidationError(
+                f"unsupported route recompute schema version {self.schema_version}"
+            )
+        for name in _SUMMARY_COUNT_FIELDS:
+            _require_non_negative_int(name, getattr(self, name))
+        if self.rank_observation_inconsistent not in (0, 1):
+            raise RecomputeRouteValidationError(
+                "rank_observation_inconsistent must be zero or one"
+            )
+        if self.exact_pair_count + self.mismatch_pair_count != self.compared_pair_count:
+            raise RecomputeRouteValidationError(
+                "exact and mismatch pair counts must equal compared_pair_count"
+            )
+        if self.completed_forward_pair_count > self.forward_pair_count:
+            raise RecomputeRouteValidationError(
+                "completed_forward_pair_count exceeds forward_pair_count"
+            )
+        if self.compared_pair_count > self.completed_forward_pair_count:
+            raise RecomputeRouteValidationError(
+                "compared_pair_count exceeds completed_forward_pair_count"
+            )
+        if self.mismatch_layer_count > self.compared_layer_count:
+            raise RecomputeRouteValidationError(
+                "mismatch_layer_count exceeds compared_layer_count"
+            )
+        if self.mismatch_token_count > self.compared_token_count:
+            raise RecomputeRouteValidationError(
+                "mismatch_token_count exceeds compared_token_count"
+            )
+        if self.mismatch_slot_count > self.compared_slot_count:
+            raise RecomputeRouteValidationError(
+                "mismatch_slot_count exceeds compared_slot_count"
+            )
+
+    @property
+    def unrecomputed_pair_count(self) -> int:
+        return self.forward_pair_count - self.completed_forward_pair_count
+
+    @property
+    def exact_match_fraction(self) -> float | None:
+        if self.compared_pair_count == 0:
+            return None
+        return self.exact_pair_count / self.compared_pair_count
+
+    @property
+    def has_failure(self) -> bool:
+        return bool(
+            self.mismatch_pair_count
+            or self.invalid_pair_count
+            or self.unrecomputed_pair_count
+            or self.rank_observation_inconsistent
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        result = {name: getattr(self, name) for name in _SUMMARY_COUNT_FIELDS}
+        result.update(
+            {
+                "exact_match_fraction": self.exact_match_fraction,
+                "has_failure": self.has_failure,
+                "schema_version": self.schema_version,
+                "unrecomputed_pair_count": self.unrecomputed_pair_count,
+            }
+        )
+        return result
+
+    def to_metrics(self) -> dict[str, float]:
+        metrics = {
+            "route_recompute_compared_pairs": float(self.compared_pair_count),
+            "route_recompute_completed_forward_pairs": float(
+                self.completed_forward_pair_count
+            ),
+            "route_recompute_forward_pairs": float(self.forward_pair_count),
+            "route_recompute_invalid_pairs": float(self.invalid_pair_count),
+            "route_recompute_mismatch_layers": float(self.mismatch_layer_count),
+            "route_recompute_mismatch_pairs": float(self.mismatch_pair_count),
+            "route_recompute_mismatch_slots": float(self.mismatch_slot_count),
+            "route_recompute_mismatch_tokens": float(self.mismatch_token_count),
+            "route_recompute_rank_inconsistent": float(
+                self.rank_observation_inconsistent
+            ),
+            "route_recompute_unrecomputed_pairs": float(self.unrecomputed_pair_count),
+        }
+        if self.exact_match_fraction is not None:
+            metrics["forward_recompute_route_match"] = self.exact_match_fraction
+        return metrics
+
+    def _count_tuple(self) -> tuple[int, ...]:
+        return tuple(getattr(self, name) for name in _SUMMARY_COUNT_FIELDS)
+
+    @classmethod
+    def _from_count_tuple(cls, counts: Sequence[int]) -> RouteRecomputeSummaryV0:
+        if len(counts) != len(_SUMMARY_COUNT_FIELDS):
+            raise RecomputeRouteValidationError(
+                "route recompute summary count vector has the wrong length"
+            )
+        return cls(**dict(zip(_SUMMARY_COUNT_FIELDS, counts)))
+
+    @classmethod
+    def merge(
+        cls, summaries: Sequence[RouteRecomputeSummaryV0]
+    ) -> RouteRecomputeSummaryV0:
+        """Merge rank-local summaries and flag incomplete rank geometry."""
+        if isinstance(summaries, (str, bytes)) or not isinstance(summaries, Sequence):
+            raise RecomputeRouteValidationError("summaries must be a sequence")
+        summaries = tuple(summaries)
+        if not summaries or any(
+            not isinstance(summary, RouteRecomputeSummaryV0) for summary in summaries
+        ):
+            raise RecomputeRouteValidationError(
+                "summaries must contain RouteRecomputeSummaryV0 values"
+            )
+        counts = {
+            name: sum(getattr(summary, name) for summary in summaries)
+            for name in _SUMMARY_COUNT_FIELDS
+            if name != "rank_observation_inconsistent"
+        }
+        geometries = {
+            (
+                summary.forward_pair_count,
+                summary.completed_forward_pair_count,
+                summary.compared_layer_count,
+            )
+            for summary in summaries
+        }
+        counts["rank_observation_inconsistent"] = int(
+            any(summary.rank_observation_inconsistent for summary in summaries)
+            or len(geometries) != 1
+        )
+        return cls(**counts)
+
+
+class RouteRecomputeDiagnosticsV0:
+    """Thread-safe bounded state shared by checkpointed modules in one batch."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._counts = {name: 0 for name in _SUMMARY_COUNT_FIELDS}
+        self._last_report: RecomputeRoutePairReportV0 | None = None
+        self._last_invalid_reason: str | None = None
+
+    def reset(self) -> None:
+        with self._lock:
+            self._counts = {name: 0 for name in _SUMMARY_COUNT_FIELDS}
+            self._last_report = None
+            self._last_invalid_reason = None
+
+    def record_forward_pair(self) -> None:
+        with self._lock:
+            self._counts["forward_pair_count"] += 1
+
+    def record_report(self, report: RecomputeRoutePairReportV0) -> None:
+        if not isinstance(report, RecomputeRoutePairReportV0):
+            raise RecomputeRouteValidationError(
+                "report must be RecomputeRoutePairReportV0"
+            )
+        with self._lock:
+            self._counts["completed_forward_pair_count"] += 1
+            self._counts["compared_pair_count"] += 1
+            self._counts["exact_pair_count"] += int(report.exact_match)
+            self._counts["mismatch_pair_count"] += int(not report.exact_match)
+            self._counts["compared_layer_count"] += report.layer_count
+            self._counts["compared_token_count"] += report.token_count
+            self._counts["compared_slot_count"] += report.slot_count
+            self._counts["mismatch_layer_count"] += report.mismatch_layer_count
+            self._counts["mismatch_token_count"] += report.mismatch_token_count
+            self._counts["mismatch_slot_count"] += report.mismatch_slot_count
+            self._last_report = report
+
+    def record_invalid_pair(
+        self, reason: str, *, completes_forward_pair: bool = False
+    ) -> None:
+        if not isinstance(reason, str) or not reason:
+            raise RecomputeRouteValidationError("invalid-pair reason must be text")
+        with self._lock:
+            self._counts["invalid_pair_count"] += 1
+            self._counts["completed_forward_pair_count"] += int(completes_forward_pair)
+            self._last_invalid_reason = reason[:1024]
+
+    def snapshot(self) -> RouteRecomputeSummaryV0:
+        with self._lock:
+            return RouteRecomputeSummaryV0(**self._counts)
+
+    @property
+    def last_report(self) -> RecomputeRoutePairReportV0 | None:
+        with self._lock:
+            return self._last_report
+
+    @property
+    def last_invalid_reason(self) -> str | None:
+        with self._lock:
+            return self._last_invalid_reason
+
+
+def _extract_route_layers(output: Any) -> tuple[Tensor, ...]:
+    if not isinstance(output, Mapping):
+        return ()
+    stats = output.get("router_stats")
+    if stats is None:
+        return ()
+    if isinstance(stats, Mapping):
+        entries = (stats,)
+    elif isinstance(stats, Sequence) and not isinstance(stats, (str, bytes)):
+        entries = tuple(stats)
+    else:
+        raise RecomputeRouteValidationError(
+            "router_stats must be a mapping or a sequence of mappings"
+        )
+    layers = []
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, Mapping) or "topk_indices" not in entry:
+            raise RecomputeRouteValidationError(
+                f"router_stats[{index}] must contain topk_indices"
+            )
+        layers.append(
+            _normalize_route_tensor(
+                f"router_stats[{index}].topk_indices", entry["topk_indices"]
+            )
+        )
+    return tuple(layers)
+
+
+class RouteCheckpointPairV0:
+    """Per-checkpoint observer correlated by PyTorch's two phase contexts."""
+
+    def __init__(self, diagnostics: RouteRecomputeDiagnosticsV0) -> None:
+        if not isinstance(diagnostics, RouteRecomputeDiagnosticsV0):
+            raise RecomputeRouteValidationError(
+                "diagnostics must be RouteRecomputeDiagnosticsV0"
+            )
+        self._diagnostics = diagnostics
+        self._phase: str | None = None
+        self._forward_routes: tuple[Tensor, ...] | None = None
+        self._forward_observed = False
+        self._forward_counted = False
+        self._forward_completed = False
+        self._invalid = False
+        self._completed = False
+
+    def _record_invalid(self, reason: str) -> None:
+        if not self._invalid:
+            completes_forward_pair = (
+                self._forward_counted and not self._forward_completed
+            )
+            self._diagnostics.record_invalid_pair(
+                reason,
+                completes_forward_pair=completes_forward_pair,
+            )
+            self._forward_completed = self._forward_completed or completes_forward_pair
+            self._invalid = True
+
+    @contextmanager
+    def _phase_context(self, phase: str) -> Iterator[None]:
+        if self._phase is not None:
+            self._record_invalid("route checkpoint phase contexts overlapped")
+        previous = self._phase
+        self._phase = phase
+        try:
+            yield
+        finally:
+            self._phase = previous
+
+    def context_fn(
+        self,
+    ) -> tuple[AbstractContextManager[None], AbstractContextManager[None]]:
+        """Return original-forward and recompute contexts for checkpoint()."""
+        return (
+            self._phase_context("forward"),
+            self._phase_context("recompute"),
+        )
+
+    def observe(self, output: Any) -> None:
+        """Observe one module output without retaining its autograd tensors."""
+        if self._completed:
+            self._record_invalid("route checkpoint pair produced extra observations")
+            return
+        try:
+            layers = _extract_route_layers(output)
+        except RecomputeRouteValidationError as exc:
+            if self._phase == "forward" and not self._forward_observed:
+                self._diagnostics.record_forward_pair()
+                self._forward_observed = True
+                self._forward_counted = True
+            self._record_invalid(str(exc))
+            if self._phase == "recompute":
+                self._completed = True
+            return
+
+        if self._phase == "forward":
+            if self._forward_observed:
+                self._record_invalid("checkpoint pair observed forward more than once")
+                return
+            self._forward_observed = True
+            self._forward_routes = layers
+            if layers:
+                self._diagnostics.record_forward_pair()
+                self._forward_counted = True
+            return
+
+        if self._phase != "recompute":
+            self._record_invalid("route observation occurred outside checkpoint phases")
+            return
+        self._completed = True
+        if self._invalid:
+            return
+        if not self._forward_observed or self._forward_routes is None:
+            self._record_invalid(
+                "recompute route arrived without a forward observation"
+            )
+            return
+        if not self._forward_routes and not layers:
+            self._forward_routes = None
+            return
+        if not self._forward_routes or not layers:
+            self._record_invalid(
+                "forward and recompute disagree on whether routed layers were present"
+            )
+            self._forward_routes = None
+            return
+        try:
+            report = _compare_normalized_routes(self._forward_routes, layers)
+        except RecomputeRouteValidationError as exc:
+            self._record_invalid(str(exc))
+            self._forward_routes = None
+            return
+        self._forward_routes = None
+        self._diagnostics.record_report(report)
+        self._forward_completed = True
+
+
+def synchronize_route_recompute_summary(
+    summary: RouteRecomputeSummaryV0,
+    *,
+    device: torch.device | str | None = None,
+) -> RouteRecomputeSummaryV0:
+    """Return the same merged summary on every initialized distributed rank."""
+    if not isinstance(summary, RouteRecomputeSummaryV0):
+        raise RecomputeRouteValidationError("summary must be RouteRecomputeSummaryV0")
+    if not dist.is_available() or not dist.is_initialized():
+        return summary
+    if device is None:
+        backend = str(dist.get_backend()).lower()
+        device = (
+            torch.device("cuda", torch.cuda.current_device())
+            if "nccl" in backend
+            else torch.device("cpu")
+        )
+    count_tensor = torch.tensor(
+        summary._count_tuple(), dtype=torch.int64, device=device
+    )
+    gathered = [torch.empty_like(count_tensor) for _ in range(dist.get_world_size())]
+    dist.all_gather(gathered, count_tensor)
+    rank_summaries = tuple(
+        RouteRecomputeSummaryV0._from_count_tuple(item.cpu().tolist())
+        for item in gathered
+    )
+    return RouteRecomputeSummaryV0.merge(rank_summaries)

--- a/astrai/moe/route_metrics.py
+++ b/astrai/moe/route_metrics.py
@@ -1,0 +1,166 @@
+"""Pure alignment diagnostics for compatible versioned MoE route traces."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import torch
+
+from astrai.moe.route_trace import (
+    RouteTraceV0,
+    RouteTraceValidationError,
+    require_semantically_aligned_traces,
+)
+
+
+@dataclass(frozen=True)
+class RouteAlignmentMetricsV0:
+    """Aggregated behavior/current route alignment without changing policy."""
+
+    behavior_policy_version: int
+    current_policy_version: int
+    valid_token_count: int
+    compared_token_layer_count: int
+    ordered_topk_match_fraction: float
+    unordered_topk_overlap_fraction: float
+    route_set_flip_fraction: float
+    selected_weight_l1_mean: float | None
+    behavior_margin_mean: float | None
+    behavior_fragile_fraction: float | None
+    fragile_margin_threshold: float | None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-compatible scalar diagnostics."""
+        return asdict(self)
+
+
+def compute_topk_margin(router_scores: torch.Tensor, top_k: int) -> torch.Tensor:
+    """Compute top-k versus top-(k+1) margin in FP32.
+
+    The explicit FP32 conversion gives BF16/FP16 callers one documented
+    diagnostic reference. It does not choose or override expert IDs.
+    """
+    if not isinstance(router_scores, torch.Tensor):
+        raise RouteTraceValidationError("router_scores must be a torch.Tensor")
+    if not router_scores.is_floating_point() or router_scores.ndim < 1:
+        raise RouteTraceValidationError("router_scores must be a floating tensor")
+    if isinstance(top_k, bool) or not isinstance(top_k, int) or top_k < 1:
+        raise RouteTraceValidationError("top_k must be a positive integer")
+    if top_k >= router_scores.shape[-1]:
+        raise RouteTraceValidationError(
+            "top-k margin requires at least one unselected expert"
+        )
+    if not bool(torch.isfinite(router_scores).all().item()):
+        raise RouteTraceValidationError("router_scores must be finite")
+    values = torch.topk(router_scores.float(), top_k + 1, dim=-1, sorted=True).values
+    return values[..., top_k - 1] - values[..., top_k]
+
+
+def _valid_token_layer_mask(trace: RouteTraceV0) -> torch.Tensor:
+    if trace.valid_mask is None:
+        token_mask = torch.ones(
+            trace.token_layout.token_count,
+            dtype=torch.bool,
+            device=trace.topk_ids.device,
+        )
+    else:
+        token_mask = trace.valid_mask
+    return token_mask[:, None].expand(-1, trace.router_schema.num_moe_layers)
+
+
+def _selected_weight_l1(
+    behavior: RouteTraceV0, current: RouteTraceV0
+) -> torch.Tensor | None:
+    if behavior.selected_weights is None or current.selected_weights is None:
+        return None
+    behavior_ids = behavior.topk_ids.to(dtype=torch.int64)
+    current_ids = current.topk_ids.to(dtype=torch.int64)
+    behavior_weights = behavior.selected_weights.float()
+    current_weights = current.selected_weights.float()
+    same_expert = behavior_ids.unsqueeze(-1) == current_ids.unsqueeze(-2)
+    current_for_behavior = (
+        same_expert.to(dtype=current_weights.dtype) * current_weights.unsqueeze(-2)
+    ).sum(dim=-1)
+    behavior_mass_delta = (behavior_weights - current_for_behavior).abs().sum(dim=-1)
+    unmatched_current = ~same_expert.any(dim=-2)
+    unmatched_current_mass = (current_weights * unmatched_current).sum(dim=-1)
+    return behavior_mass_delta + unmatched_current_mass
+
+
+def compare_route_traces(
+    behavior: RouteTraceV0,
+    current: RouteTraceV0,
+    *,
+    fragile_margin_threshold: float | None = None,
+) -> RouteAlignmentMetricsV0:
+    """Compare exact ordered IDs, expert sets, selected mass, and margin.
+
+    Identity versions may differ because the purpose is to measure drift, but
+    router semantics, token layout, validity mask, and device must match
+    exactly. Missing optional tensors produce explicit ``None`` metrics rather
+    than fabricated zero drift.
+    """
+    require_semantically_aligned_traces(behavior, current)
+    if fragile_margin_threshold is not None:
+        if (
+            isinstance(fragile_margin_threshold, bool)
+            or not isinstance(fragile_margin_threshold, (int, float))
+            or not math.isfinite(fragile_margin_threshold)
+            or fragile_margin_threshold < 0
+        ):
+            raise RouteTraceValidationError(
+                "fragile_margin_threshold must be a finite non-negative number"
+            )
+        fragile_margin_threshold = float(fragile_margin_threshold)
+
+    valid_positions = _valid_token_layer_mask(behavior)
+    compared_positions = int(valid_positions.sum().item())
+    if compared_positions == 0:
+        raise RouteTraceValidationError(
+            "route metrics require at least one valid token-layer"
+        )
+
+    behavior_ids = behavior.topk_ids.to(dtype=torch.int64)
+    current_ids = current.topk_ids.to(dtype=torch.int64)
+    ordered_match = (behavior_ids == current_ids).all(dim=-1)
+    same_expert = behavior_ids.unsqueeze(-1) == current_ids.unsqueeze(-2)
+    overlap = same_expert.any(dim=-1).float().mean(dim=-1)
+    ordered_fraction = float(ordered_match[valid_positions].float().mean().item())
+    overlap_fraction = float(overlap[valid_positions].mean().item())
+
+    weight_l1 = _selected_weight_l1(behavior, current)
+    weight_l1_mean = (
+        float(weight_l1[valid_positions].mean().item())
+        if weight_l1 is not None
+        else None
+    )
+
+    margin_mean = None
+    fragile_fraction = None
+    if behavior.topk_margin is not None:
+        valid_margins = behavior.topk_margin.float()[valid_positions]
+        margin_mean = float(valid_margins.mean().item())
+        if fragile_margin_threshold is not None:
+            fragile_fraction = float(
+                (valid_margins < fragile_margin_threshold).float().mean().item()
+            )
+    elif fragile_margin_threshold is not None:
+        raise RouteTraceValidationError(
+            "fragile margin diagnostics require behavior topk_margin"
+        )
+
+    return RouteAlignmentMetricsV0(
+        behavior_policy_version=behavior.identity.policy_version,
+        current_policy_version=current.identity.policy_version,
+        valid_token_count=behavior.valid_token_count,
+        compared_token_layer_count=compared_positions,
+        ordered_topk_match_fraction=ordered_fraction,
+        unordered_topk_overlap_fraction=overlap_fraction,
+        route_set_flip_fraction=1.0 - overlap_fraction,
+        selected_weight_l1_mean=weight_l1_mean,
+        behavior_margin_mean=margin_mean,
+        behavior_fragile_fraction=fragile_fraction,
+        fragile_margin_threshold=fragile_margin_threshold,
+    )

--- a/astrai/moe/route_trace.py
+++ b/astrai/moe/route_trace.py
@@ -1,0 +1,944 @@
+"""Versioned, compact, and fail-closed MoE route trace artifacts.
+
+This module defines the data contract only. It does not capture routes from a
+model, alter expert dispatch, or apply replay during training. The separation
+keeps the default model path unchanged while rollout and training backends gain
+a common artifact they can validate before later integrations consume it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+import safetensors.torch as safetensors
+import torch
+from torch import Tensor
+
+ROUTE_TRACE_SCHEMA_VERSION = 0
+
+_CODEC_NAME = "astrai-route-trace-safetensors-raw-v0"
+_MANIFEST_TENSOR = "__route_trace_manifest_v0__"
+_MAX_MANIFEST_BYTES = 1024 * 1024
+_DEFAULT_MAX_SERIALIZED_BYTES = 1024 * 1024 * 1024
+_SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
+
+_FLOAT_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+_DTYPE_BY_NAME = {
+    "bool": torch.bool,
+    "bfloat16": torch.bfloat16,
+    "float16": torch.float16,
+    "float32": torch.float32,
+    "uint8": torch.uint8,
+    "uint16": torch.uint16,
+    "uint32": torch.uint32,
+}
+_TENSOR_NAMES = ("topk_ids", "selected_weights", "topk_margin", "valid_mask")
+
+
+class RouteTraceValidationError(ValueError):
+    """A route trace cannot be interpreted under the declared contract."""
+
+
+class RouteTraceLevel(str, Enum):
+    """Payload tiers supported by the version-zero contract."""
+
+    IDS = "ids"
+    IDS_WEIGHTS_MARGIN = "ids_weights_margin"
+
+
+class SelectedWeightSemantics(str, Enum):
+    """How selected expert weights relate to the full router distribution."""
+
+    FULL_SOFTMAX_SELECTED = "full-softmax-selected"
+    SELECTED_RENORMALIZED = "selected-renormalized"
+
+
+class PaddingLayout(str, Enum):
+    """Validity-mask ordering for the flattened token span."""
+
+    NONE = "none"
+    LEFT = "left"
+    RIGHT = "right"
+    EXPLICIT_MASK = "explicit-mask"
+
+
+class TokenSpanKind(str, Enum):
+    """Relationship of the captured span to prompt and response tokens."""
+
+    FULL_SEQUENCE = "full-sequence"
+    PROMPT = "prompt"
+    RESPONSE = "response"
+    CONTIGUOUS = "contiguous-span"
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    try:
+        encoded = json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError) as exc:
+        raise RouteTraceValidationError(
+            "value is not canonical-JSON serializable"
+        ) from exc
+    return encoded.encode("utf-8")
+
+
+def canonical_json_digest(value: Any) -> str:
+    """Return a content-addressed SHA-256 digest for JSON-compatible metadata."""
+    return hashlib.sha256(_canonical_json_bytes(value)).hexdigest()
+
+
+def _require_int(
+    name: str, value: Any, *, minimum: int, maximum: int | None = None
+) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise RouteTraceValidationError(f"{name} must be an integer >= {minimum}")
+    if maximum is not None and value > maximum:
+        raise RouteTraceValidationError(f"{name} must be <= {maximum}")
+    return value
+
+
+def _require_text(name: str, value: Any) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value or len(value) > 1024:
+        raise RouteTraceValidationError(f"{name} must be a non-empty bounded string")
+    return value
+
+
+def _require_digest(name: str, value: Any) -> str:
+    if not isinstance(value, str) or _SHA256_PATTERN.fullmatch(value) is None:
+        raise RouteTraceValidationError(f"{name} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _require_exact_keys(
+    value: Any, expected: set[str], label: str
+) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise RouteTraceValidationError(f"{label} must be a mapping")
+    keys = set(value)
+    if keys != expected:
+        missing = sorted(expected - keys)
+        unknown = sorted(keys - expected)
+        raise RouteTraceValidationError(
+            f"{label} keys do not match version-zero schema; missing={missing}, unknown={unknown}"
+        )
+    return value
+
+
+def _parse_enum(enum_type: type[Enum], name: str, value: Any) -> Enum:
+    try:
+        return enum_type(value)
+    except (TypeError, ValueError) as exc:
+        raise RouteTraceValidationError(f"unsupported {name}: {value!r}") from exc
+
+
+@dataclass(frozen=True)
+class RouterSchemaV0:
+    """Semantic identity required to interpret route IDs and selected weights."""
+
+    num_moe_layers: int
+    num_experts: int
+    top_k: int
+    expert_parallel_world_size: int
+    score_function: str
+    score_dtype: str
+    expert_id_ordering: str
+    selected_weight_semantics: SelectedWeightSemantics
+    token_ordering: str
+    padding_layout: PaddingLayout
+    backend: str
+    kernel_semantics_version: str
+    parallel_layout_hash: str
+
+    def __post_init__(self) -> None:
+        _require_int("num_moe_layers", self.num_moe_layers, minimum=1)
+        _require_int("num_experts", self.num_experts, minimum=1, maximum=2**32)
+        _require_int("top_k", self.top_k, minimum=1, maximum=self.num_experts)
+        _require_int(
+            "expert_parallel_world_size", self.expert_parallel_world_size, minimum=1
+        )
+        for name in (
+            "score_function",
+            "score_dtype",
+            "expert_id_ordering",
+            "token_ordering",
+            "backend",
+            "kernel_semantics_version",
+        ):
+            _require_text(name, getattr(self, name))
+        if not isinstance(self.selected_weight_semantics, SelectedWeightSemantics):
+            raise RouteTraceValidationError(
+                "selected_weight_semantics must use the declared enum"
+            )
+        if not isinstance(self.padding_layout, PaddingLayout):
+            raise RouteTraceValidationError("padding_layout must use the declared enum")
+        _require_digest("parallel_layout_hash", self.parallel_layout_hash)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical JSON-compatible schema representation."""
+        return {
+            "backend": self.backend,
+            "expert_id_ordering": self.expert_id_ordering,
+            "expert_parallel_world_size": self.expert_parallel_world_size,
+            "kernel_semantics_version": self.kernel_semantics_version,
+            "num_experts": self.num_experts,
+            "num_moe_layers": self.num_moe_layers,
+            "padding_layout": self.padding_layout.value,
+            "parallel_layout_hash": self.parallel_layout_hash,
+            "score_dtype": self.score_dtype,
+            "score_function": self.score_function,
+            "selected_weight_semantics": self.selected_weight_semantics.value,
+            "token_ordering": self.token_ordering,
+            "top_k": self.top_k,
+        }
+
+    @property
+    def fingerprint(self) -> str:
+        """Return the content address used as ``router_schema_hash``."""
+        return canonical_json_digest(
+            {"route_trace_schema_version": ROUTE_TRACE_SCHEMA_VERSION, **self.to_dict()}
+        )
+
+    @classmethod
+    def from_dict(cls, value: Any) -> RouterSchemaV0:
+        """Parse a strict version-zero router schema."""
+        fields = {
+            "backend",
+            "expert_id_ordering",
+            "expert_parallel_world_size",
+            "kernel_semantics_version",
+            "num_experts",
+            "num_moe_layers",
+            "padding_layout",
+            "parallel_layout_hash",
+            "score_dtype",
+            "score_function",
+            "selected_weight_semantics",
+            "token_ordering",
+            "top_k",
+        }
+        value = _require_exact_keys(value, fields, "router_schema")
+        return cls(
+            num_moe_layers=value["num_moe_layers"],
+            num_experts=value["num_experts"],
+            top_k=value["top_k"],
+            expert_parallel_world_size=value["expert_parallel_world_size"],
+            score_function=value["score_function"],
+            score_dtype=value["score_dtype"],
+            expert_id_ordering=value["expert_id_ordering"],
+            selected_weight_semantics=_parse_enum(
+                SelectedWeightSemantics,
+                "selected_weight_semantics",
+                value["selected_weight_semantics"],
+            ),
+            token_ordering=value["token_ordering"],
+            padding_layout=_parse_enum(
+                PaddingLayout, "padding_layout", value["padding_layout"]
+            ),
+            backend=value["backend"],
+            kernel_semantics_version=value["kernel_semantics_version"],
+            parallel_layout_hash=value["parallel_layout_hash"],
+        )
+
+
+@dataclass(frozen=True)
+class RouteIdentityV0:
+    """Versions and revisions that attribute a trace to one behavior policy."""
+
+    policy_version: int
+    model_revision: str
+    router_state_version: int
+    checkpoint_revision: str
+    router_schema_hash: str
+    load_controller_version: int = 0
+
+    def __post_init__(self) -> None:
+        _require_int("policy_version", self.policy_version, minimum=0)
+        _require_int("router_state_version", self.router_state_version, minimum=0)
+        _require_int("load_controller_version", self.load_controller_version, minimum=0)
+        _require_text("model_revision", self.model_revision)
+        _require_text("checkpoint_revision", self.checkpoint_revision)
+        _require_digest("router_schema_hash", self.router_schema_hash)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical JSON-compatible identity representation."""
+        return {
+            "checkpoint_revision": self.checkpoint_revision,
+            "load_controller_version": self.load_controller_version,
+            "model_revision": self.model_revision,
+            "policy_version": self.policy_version,
+            "router_schema_hash": self.router_schema_hash,
+            "router_state_version": self.router_state_version,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> RouteIdentityV0:
+        """Parse a strict version-zero route identity."""
+        fields = {
+            "checkpoint_revision",
+            "load_controller_version",
+            "model_revision",
+            "policy_version",
+            "router_schema_hash",
+            "router_state_version",
+        }
+        value = _require_exact_keys(value, fields, "identity")
+        return cls(**{name: value[name] for name in fields})
+
+
+@dataclass(frozen=True)
+class RouteTokenLayoutV0:
+    """One sample's flattened contiguous token span and prompt boundary."""
+
+    sample_id: str
+    sequence_token_count: int
+    prompt_token_count: int
+    token_offset: int
+    token_count: int
+    span_kind: TokenSpanKind
+
+    def __post_init__(self) -> None:
+        _require_text("sample_id", self.sample_id)
+        _require_int("sequence_token_count", self.sequence_token_count, minimum=0)
+        _require_int(
+            "prompt_token_count",
+            self.prompt_token_count,
+            minimum=0,
+            maximum=self.sequence_token_count,
+        )
+        _require_int("token_offset", self.token_offset, minimum=0)
+        _require_int("token_count", self.token_count, minimum=0)
+        if self.token_offset + self.token_count > self.sequence_token_count:
+            raise RouteTraceValidationError(
+                "captured token span exceeds the sequence boundary"
+            )
+        if not isinstance(self.span_kind, TokenSpanKind):
+            raise RouteTraceValidationError("span_kind must use the declared enum")
+        if self.span_kind is TokenSpanKind.FULL_SEQUENCE and (
+            self.token_offset != 0 or self.token_count != self.sequence_token_count
+        ):
+            raise RouteTraceValidationError(
+                "full-sequence span must cover the complete sequence"
+            )
+        if self.span_kind is TokenSpanKind.PROMPT and (
+            self.token_offset != 0 or self.token_count != self.prompt_token_count
+        ):
+            raise RouteTraceValidationError(
+                "prompt span must exactly cover the prompt boundary"
+            )
+        if (
+            self.span_kind is TokenSpanKind.RESPONSE
+            and self.token_offset < self.prompt_token_count
+        ):
+            raise RouteTraceValidationError(
+                "response span cannot begin inside the prompt"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical JSON-compatible token layout."""
+        return {
+            "prompt_token_count": self.prompt_token_count,
+            "sample_id": self.sample_id,
+            "sequence_token_count": self.sequence_token_count,
+            "span_kind": self.span_kind.value,
+            "token_count": self.token_count,
+            "token_offset": self.token_offset,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> RouteTokenLayoutV0:
+        """Parse a strict version-zero token layout."""
+        fields = {
+            "prompt_token_count",
+            "sample_id",
+            "sequence_token_count",
+            "span_kind",
+            "token_count",
+            "token_offset",
+        }
+        value = _require_exact_keys(value, fields, "token_layout")
+        return cls(
+            sample_id=value["sample_id"],
+            sequence_token_count=value["sequence_token_count"],
+            prompt_token_count=value["prompt_token_count"],
+            token_offset=value["token_offset"],
+            token_count=value["token_count"],
+            span_kind=_parse_enum(TokenSpanKind, "span_kind", value["span_kind"]),
+        )
+
+
+def recommended_route_id_dtype(num_experts: int) -> torch.dtype:
+    """Return the narrowest unsigned dtype that represents every expert ID."""
+    _require_int("num_experts", num_experts, minimum=1, maximum=2**32)
+    if num_experts <= 2**8:
+        return torch.uint8
+    if num_experts <= 2**16:
+        return torch.uint16
+    return torch.uint32
+
+
+def pack_route_ids(topk_ids: Tensor, num_experts: int) -> Tensor:
+    """Validate expert IDs and copy them into the canonical compact dtype."""
+    if not isinstance(topk_ids, Tensor):
+        raise RouteTraceValidationError("topk_ids must be a torch.Tensor")
+    integral_dtypes = (
+        torch.int8,
+        torch.int16,
+        torch.int32,
+        torch.int64,
+        torch.uint8,
+        torch.uint16,
+        torch.uint32,
+    )
+    if topk_ids.dtype not in integral_dtypes:
+        raise RouteTraceValidationError("topk_ids must use an integer dtype")
+    _require_int("num_experts", num_experts, minimum=1, maximum=2**32)
+    ids64 = topk_ids.detach().to(dtype=torch.int64)
+    if ids64.numel() and (ids64.min().item() < 0 or ids64.max().item() >= num_experts):
+        raise RouteTraceValidationError(
+            "topk_ids contains an expert outside the declared range"
+        )
+    return (
+        topk_ids.detach()
+        .to(dtype=recommended_route_id_dtype(num_experts), copy=True)
+        .contiguous()
+    )
+
+
+@dataclass(frozen=True, eq=False)
+class RouteTraceV0:
+    """A compact route artifact for one contiguous token span.
+
+    Tensors use token-major shapes ``[T, L, K]`` for IDs and weights,
+    ``[T, L]`` for margins, and ``[T]`` for the optional validity mask. The
+    constructor validates all identity, shape, dtype, range, and padding
+    invariants. Consumers must validate again at their trust boundary because
+    tensors remain mutable Python objects even though this dataclass is frozen.
+    """
+
+    identity: RouteIdentityV0
+    router_schema: RouterSchemaV0
+    token_layout: RouteTokenLayoutV0
+    level: RouteTraceLevel
+    topk_ids: Tensor
+    selected_weights: Tensor | None = None
+    topk_margin: Tensor | None = None
+    valid_mask: Tensor | None = None
+
+    def __post_init__(self) -> None:
+        validate_route_trace(self)
+
+    @property
+    def valid_token_count(self) -> int:
+        """Return the number of captured tokens marked valid."""
+        if self.valid_mask is None:
+            return self.token_layout.token_count
+        return int(self.valid_mask.sum().item())
+
+    @property
+    def payload_nbytes(self) -> int:
+        """Return exact tensor payload bytes, excluding the manifest/container."""
+        tensors = (
+            self.topk_ids,
+            self.selected_weights,
+            self.topk_margin,
+            self.valid_mask,
+        )
+        return sum(
+            tensor.numel() * tensor.element_size()
+            for tensor in tensors
+            if tensor is not None
+        )
+
+    @property
+    def artifact_digest(self) -> str:
+        """Return the content address of the canonical serialized artifact."""
+        return hashlib.sha256(RouteTraceCodecV0.dumps(self)).hexdigest()
+
+
+def _effective_valid_mask(trace: RouteTraceV0) -> Tensor:
+    if trace.valid_mask is not None:
+        return trace.valid_mask
+    return torch.ones(
+        trace.token_layout.token_count, dtype=torch.bool, device=trace.topk_ids.device
+    )
+
+
+def _validate_padding_mask(trace: RouteTraceV0, mask: Tensor) -> None:
+    layout = trace.router_schema.padding_layout
+    if layout is PaddingLayout.EXPLICIT_MASK and trace.valid_mask is None:
+        raise RouteTraceValidationError("explicit-mask layout requires valid_mask")
+    if layout is PaddingLayout.NONE and mask.numel() and not bool(mask.all().item()):
+        raise RouteTraceValidationError(
+            "padding_layout=none cannot contain invalid tokens"
+        )
+    if mask.numel() < 2:
+        return
+    if layout is PaddingLayout.LEFT and bool((mask[:-1] & ~mask[1:]).any().item()):
+        raise RouteTraceValidationError(
+            "left padding mask must be false tokens followed by true tokens"
+        )
+    if layout is PaddingLayout.RIGHT and bool((~mask[:-1] & mask[1:]).any().item()):
+        raise RouteTraceValidationError(
+            "right padding mask must be true tokens followed by false tokens"
+        )
+
+
+def _validate_float_tensor(
+    name: str, tensor: Tensor, expected_shape: tuple[int, ...], device: torch.device
+) -> None:
+    if not isinstance(tensor, Tensor):
+        raise RouteTraceValidationError(f"{name} must be a torch.Tensor")
+    if tensor.layout is not torch.strided or tensor.device.type == "meta":
+        raise RouteTraceValidationError(f"{name} must be a materialized strided tensor")
+    if tensor.dtype not in _FLOAT_DTYPES:
+        raise RouteTraceValidationError(
+            f"{name} must use float16, bfloat16, or float32"
+        )
+    if tuple(tensor.shape) != expected_shape:
+        raise RouteTraceValidationError(
+            f"{name} shape must be {expected_shape}, got {tuple(tensor.shape)}"
+        )
+    if tensor.device != device:
+        raise RouteTraceValidationError(
+            f"{name} must be on the same device as topk_ids"
+        )
+    if tensor.requires_grad:
+        raise RouteTraceValidationError(f"{name} must be detached from autograd")
+    negative_zero = (tensor == 0) & torch.signbit(tensor)
+    if negative_zero.numel() and bool(negative_zero.any().item()):
+        raise RouteTraceValidationError(
+            f"{name} must use canonical positive zero values"
+        )
+
+
+def validate_route_trace(trace: RouteTraceV0) -> None:
+    """Validate one trace's complete internal contract, failing closed."""
+    if not isinstance(trace.identity, RouteIdentityV0):
+        raise RouteTraceValidationError("identity must be RouteIdentityV0")
+    if not isinstance(trace.router_schema, RouterSchemaV0):
+        raise RouteTraceValidationError("router_schema must be RouterSchemaV0")
+    if not isinstance(trace.token_layout, RouteTokenLayoutV0):
+        raise RouteTraceValidationError("token_layout must be RouteTokenLayoutV0")
+    if not isinstance(trace.level, RouteTraceLevel):
+        raise RouteTraceValidationError("level must use the declared enum")
+    if trace.identity.router_schema_hash != trace.router_schema.fingerprint:
+        raise RouteTraceValidationError(
+            "router_schema_hash does not match the declared router schema"
+        )
+    if not isinstance(trace.topk_ids, Tensor):
+        raise RouteTraceValidationError("topk_ids must be a torch.Tensor")
+    if (
+        trace.topk_ids.layout is not torch.strided
+        or trace.topk_ids.device.type == "meta"
+    ):
+        raise RouteTraceValidationError(
+            "topk_ids must be a materialized strided tensor"
+        )
+
+    schema = trace.router_schema
+    token_count = trace.token_layout.token_count
+    expected_ids_shape = (token_count, schema.num_moe_layers, schema.top_k)
+    if tuple(trace.topk_ids.shape) != expected_ids_shape:
+        raise RouteTraceValidationError(
+            f"topk_ids shape must be {expected_ids_shape}, got {tuple(trace.topk_ids.shape)}"
+        )
+    expected_id_dtype = recommended_route_id_dtype(schema.num_experts)
+    if trace.topk_ids.dtype is not expected_id_dtype:
+        raise RouteTraceValidationError(
+            f"topk_ids must use compact dtype {expected_id_dtype}, got {trace.topk_ids.dtype}"
+        )
+
+    if trace.valid_mask is not None:
+        if not isinstance(trace.valid_mask, Tensor):
+            raise RouteTraceValidationError("valid_mask must be a torch.Tensor")
+        if (
+            trace.valid_mask.layout is not torch.strided
+            or trace.valid_mask.device.type == "meta"
+        ):
+            raise RouteTraceValidationError(
+                "valid_mask must be a materialized strided tensor"
+            )
+        if trace.valid_mask.dtype is not torch.bool or tuple(
+            trace.valid_mask.shape
+        ) != (token_count,):
+            raise RouteTraceValidationError(
+                f"valid_mask must be bool with shape {(token_count,)}"
+            )
+        if trace.valid_mask.device != trace.topk_ids.device:
+            raise RouteTraceValidationError(
+                "valid_mask must be on the same device as topk_ids"
+            )
+    mask = _effective_valid_mask(trace)
+    _validate_padding_mask(trace, mask)
+
+    ids64 = trace.topk_ids.to(dtype=torch.int64)
+    if ids64.numel() and (
+        ids64.min().item() < 0 or ids64.max().item() >= schema.num_experts
+    ):
+        raise RouteTraceValidationError(
+            "topk_ids contains an expert outside the declared range"
+        )
+    valid_rows = ids64[mask]
+    if schema.top_k > 1 and valid_rows.numel():
+        ordered_ids = valid_rows.sort(dim=-1).values
+        if bool((ordered_ids[..., 1:] == ordered_ids[..., :-1]).any().item()):
+            raise RouteTraceValidationError(
+                "topk_ids contains duplicate experts in a valid top-k row"
+            )
+    invalid_mask = ~mask
+    if (
+        invalid_mask.numel()
+        and bool(invalid_mask.any().item())
+        and bool(torch.count_nonzero(ids64[invalid_mask]).item())
+    ):
+        raise RouteTraceValidationError(
+            "invalid token rows must use canonical zero expert IDs"
+        )
+
+    rich_level = trace.level is RouteTraceLevel.IDS_WEIGHTS_MARGIN
+    if rich_level and (trace.selected_weights is None or trace.topk_margin is None):
+        raise RouteTraceValidationError(
+            "ids_weights_margin level requires weights and margins"
+        )
+    if not rich_level and (
+        trace.selected_weights is not None or trace.topk_margin is not None
+    ):
+        raise RouteTraceValidationError("ids level cannot carry weights or margins")
+
+    if trace.selected_weights is not None:
+        _validate_float_tensor(
+            "selected_weights",
+            trace.selected_weights,
+            expected_ids_shape,
+            trace.topk_ids.device,
+        )
+        valid_weights = trace.selected_weights.float()[mask]
+        if valid_weights.numel():
+            if not bool(torch.isfinite(valid_weights).all().item()) or bool(
+                (valid_weights < 0).any().item()
+            ):
+                raise RouteTraceValidationError(
+                    "selected_weights must be finite and non-negative"
+                )
+            weight_sums = valid_weights.sum(dim=-1)
+            if (
+                schema.selected_weight_semantics
+                is SelectedWeightSemantics.SELECTED_RENORMALIZED
+            ):
+                if not bool(
+                    torch.allclose(
+                        weight_sums, torch.ones_like(weight_sums), rtol=0, atol=5e-3
+                    )
+                ):
+                    raise RouteTraceValidationError(
+                        "renormalized selected weights must sum to one"
+                    )
+            elif bool(((weight_sums <= 0) | (weight_sums > 1.005)).any().item()):
+                raise RouteTraceValidationError(
+                    "full-softmax selected mass must be in (0, 1]"
+                )
+        if (
+            invalid_mask.numel()
+            and bool(invalid_mask.any().item())
+            and bool(torch.count_nonzero(trace.selected_weights[invalid_mask]).item())
+        ):
+            raise RouteTraceValidationError(
+                "invalid token rows must use canonical zero weights"
+            )
+
+    if trace.topk_margin is not None:
+        expected_margin_shape = (token_count, schema.num_moe_layers)
+        _validate_float_tensor(
+            "topk_margin",
+            trace.topk_margin,
+            expected_margin_shape,
+            trace.topk_ids.device,
+        )
+        valid_margins = trace.topk_margin.float()[mask]
+        if valid_margins.numel() and (
+            not bool(torch.isfinite(valid_margins).all().item())
+            or bool((valid_margins < 0).any().item())
+        ):
+            raise RouteTraceValidationError(
+                "topk_margin must be finite and non-negative"
+            )
+        if (
+            invalid_mask.numel()
+            and bool(invalid_mask.any().item())
+            and bool(torch.count_nonzero(trace.topk_margin[invalid_mask]).item())
+        ):
+            raise RouteTraceValidationError(
+                "invalid token rows must use canonical zero margins"
+            )
+
+
+def require_compatible_route_trace(
+    trace: RouteTraceV0,
+    *,
+    expected_identity: RouteIdentityV0,
+    expected_router_schema: RouterSchemaV0,
+    expected_token_layout: RouteTokenLayoutV0,
+    minimum_level: RouteTraceLevel = RouteTraceLevel.IDS,
+) -> None:
+    """Require exact replay identity and semantics at a consumer boundary."""
+    validate_route_trace(trace)
+    if trace.identity != expected_identity:
+        raise RouteTraceValidationError(
+            "route identity does not match the expected behavior artifact"
+        )
+    if trace.router_schema != expected_router_schema:
+        raise RouteTraceValidationError(
+            "router schema does not match the expected consumer schema"
+        )
+    if trace.token_layout != expected_token_layout:
+        raise RouteTraceValidationError(
+            "token layout does not match the expected consumer span"
+        )
+    if not isinstance(minimum_level, RouteTraceLevel):
+        raise RouteTraceValidationError("minimum_level must use the declared enum")
+    level_order = {RouteTraceLevel.IDS: 0, RouteTraceLevel.IDS_WEIGHTS_MARGIN: 1}
+    if level_order[trace.level] < level_order[minimum_level]:
+        raise RouteTraceValidationError(
+            f"trace level {trace.level.value} does not satisfy {minimum_level.value}"
+        )
+
+
+def require_semantically_aligned_traces(
+    behavior: RouteTraceV0, current: RouteTraceV0
+) -> None:
+    """Require two traces to share tensor interpretation and token alignment."""
+    validate_route_trace(behavior)
+    validate_route_trace(current)
+    if behavior.router_schema != current.router_schema:
+        raise RouteTraceValidationError(
+            "route metrics require an exact router schema match"
+        )
+    if behavior.token_layout != current.token_layout:
+        raise RouteTraceValidationError(
+            "route metrics require an exact token layout match"
+        )
+    if behavior.topk_ids.device != current.topk_ids.device:
+        raise RouteTraceValidationError(
+            "route metrics require tensors on the same device"
+        )
+    behavior_mask = _effective_valid_mask(behavior)
+    current_mask = _effective_valid_mask(current)
+    if not torch.equal(behavior_mask, current_mask):
+        raise RouteTraceValidationError(
+            "route metrics require identical validity masks"
+        )
+
+
+def _tensor_descriptor(tensor: Tensor) -> tuple[dict[str, Any], Tensor]:
+    if sys.byteorder != "little":
+        raise RouteTraceValidationError(
+            "route trace codec requires a little-endian host"
+        )
+    cpu_tensor = tensor.detach().contiguous().cpu()
+    raw_tensor = cpu_tensor.view(torch.uint8).reshape(-1).clone()
+    raw_bytes = raw_tensor.numpy().tobytes()
+    descriptor = {
+        "dtype": str(cpu_tensor.dtype).removeprefix("torch."),
+        "nbytes": len(raw_bytes),
+        "sha256": hashlib.sha256(raw_bytes).hexdigest(),
+        "shape": list(cpu_tensor.shape),
+    }
+    return descriptor, raw_tensor
+
+
+def _decode_tensor(name: str, descriptor: Any, raw_tensor: Tensor) -> Tensor:
+    descriptor = _require_exact_keys(
+        descriptor, {"dtype", "nbytes", "sha256", "shape"}, f"tensor descriptor {name}"
+    )
+    dtype_name = descriptor["dtype"]
+    if dtype_name not in _DTYPE_BY_NAME:
+        raise RouteTraceValidationError(
+            f"unsupported tensor dtype for {name}: {dtype_name!r}"
+        )
+    shape = descriptor["shape"]
+    if not isinstance(shape, list) or any(
+        isinstance(size, bool) or not isinstance(size, int) or size < 0
+        for size in shape
+    ):
+        raise RouteTraceValidationError(f"tensor shape for {name} is invalid")
+    nbytes = _require_int(f"tensor nbytes for {name}", descriptor["nbytes"], minimum=0)
+    _require_digest(f"tensor sha256 for {name}", descriptor["sha256"])
+    if raw_tensor.dtype is not torch.uint8 or raw_tensor.ndim != 1:
+        raise RouteTraceValidationError(
+            f"raw tensor for {name} must be one-dimensional uint8"
+        )
+    if raw_tensor.numel() != nbytes:
+        raise RouteTraceValidationError(
+            f"raw tensor size for {name} does not match its descriptor"
+        )
+    raw_bytes = raw_tensor.numpy().tobytes()
+    if hashlib.sha256(raw_bytes).hexdigest() != descriptor["sha256"]:
+        raise RouteTraceValidationError(f"raw tensor checksum mismatch for {name}")
+    dtype = _DTYPE_BY_NAME[dtype_name]
+    expected_nbytes = math.prod(shape) * torch.empty((), dtype=dtype).element_size()
+    if expected_nbytes != nbytes:
+        raise RouteTraceValidationError(
+            f"logical tensor size for {name} does not match its descriptor"
+        )
+    return raw_tensor.view(dtype).reshape(tuple(shape)).clone()
+
+
+class RouteTraceCodecV0:
+    """Safe bytes codec backed by safetensors and a strict JSON manifest.
+
+    Unsigned ID dtypes unsupported by older safetensors releases are stored as
+    raw uint8 buffers with checked logical dtype, shape, byte count, and SHA-256
+    descriptors. Decoding always returns detached CPU tensors and rejects
+    unknown fields, tensors, versions, trailing schema changes, and corruption.
+    """
+
+    @staticmethod
+    def dumps(trace: RouteTraceV0) -> bytes:
+        """Serialize a validated trace without pickle or executable objects."""
+        validate_route_trace(trace)
+        manifest: dict[str, Any] = {
+            "byte_order": "little",
+            "codec": _CODEC_NAME,
+            "identity": trace.identity.to_dict(),
+            "level": trace.level.value,
+            "route_trace_schema_version": ROUTE_TRACE_SCHEMA_VERSION,
+            "router_schema": trace.router_schema.to_dict(),
+            "tensors": {},
+            "token_layout": trace.token_layout.to_dict(),
+        }
+        buffers: dict[str, Tensor] = {}
+        for name in _TENSOR_NAMES:
+            tensor = getattr(trace, name)
+            if tensor is None:
+                continue
+            descriptor, raw_tensor = _tensor_descriptor(tensor)
+            manifest["tensors"][name] = descriptor
+            buffers[f"tensor.{name}"] = raw_tensor
+        manifest_bytes = _canonical_json_bytes(manifest)
+        if len(manifest_bytes) > _MAX_MANIFEST_BYTES:
+            raise RouteTraceValidationError(
+                "route trace manifest exceeds the size limit"
+            )
+        buffers[_MANIFEST_TENSOR] = torch.frombuffer(
+            bytearray(manifest_bytes), dtype=torch.uint8
+        ).clone()
+        try:
+            return safetensors.save(buffers)
+        except Exception as exc:
+            raise RouteTraceValidationError("failed to serialize route trace") from exc
+
+    @staticmethod
+    def loads(
+        data: bytes | bytearray | memoryview,
+        *,
+        max_serialized_bytes: int = _DEFAULT_MAX_SERIALIZED_BYTES,
+    ) -> RouteTraceV0:
+        """Decode and fully validate an untrusted route trace byte payload."""
+        _require_int("max_serialized_bytes", max_serialized_bytes, minimum=1)
+        if not isinstance(data, (bytes, bytearray, memoryview)):
+            raise RouteTraceValidationError("serialized route trace must be bytes-like")
+        data = bytes(data)
+        if len(data) > max_serialized_bytes:
+            raise RouteTraceValidationError(
+                "serialized route trace exceeds the size limit"
+            )
+        try:
+            tensors = safetensors.load(data)
+        except Exception as exc:
+            raise RouteTraceValidationError(
+                "invalid safetensors route trace container"
+            ) from exc
+        if _MANIFEST_TENSOR not in tensors:
+            raise RouteTraceValidationError("route trace manifest tensor is missing")
+        manifest_tensor = tensors[_MANIFEST_TENSOR]
+        if manifest_tensor.dtype is not torch.uint8 or manifest_tensor.ndim != 1:
+            raise RouteTraceValidationError(
+                "route trace manifest tensor must be one-dimensional uint8"
+            )
+        if manifest_tensor.numel() > _MAX_MANIFEST_BYTES:
+            raise RouteTraceValidationError(
+                "route trace manifest exceeds the size limit"
+            )
+        try:
+            manifest = json.loads(bytes(manifest_tensor.tolist()).decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise RouteTraceValidationError(
+                "route trace manifest is not valid UTF-8 JSON"
+            ) from exc
+        manifest = _require_exact_keys(
+            manifest,
+            {
+                "byte_order",
+                "codec",
+                "identity",
+                "level",
+                "route_trace_schema_version",
+                "router_schema",
+                "tensors",
+                "token_layout",
+            },
+            "route trace manifest",
+        )
+        if manifest["byte_order"] != "little" or sys.byteorder != "little":
+            raise RouteTraceValidationError(
+                f"unsupported route trace byte order: {manifest['byte_order']!r}"
+            )
+        if manifest["codec"] != _CODEC_NAME:
+            raise RouteTraceValidationError(
+                f"unsupported route trace codec: {manifest['codec']!r}"
+            )
+        try:
+            _require_int(
+                "route_trace_schema_version",
+                manifest["route_trace_schema_version"],
+                minimum=ROUTE_TRACE_SCHEMA_VERSION,
+                maximum=ROUTE_TRACE_SCHEMA_VERSION,
+            )
+        except RouteTraceValidationError as exc:
+            raise RouteTraceValidationError(
+                f"unsupported route trace schema version: {manifest['route_trace_schema_version']!r}"
+            ) from exc
+        tensor_descriptors = manifest["tensors"]
+        if not isinstance(tensor_descriptors, Mapping):
+            raise RouteTraceValidationError(
+                "route trace tensor table must be a mapping"
+            )
+        unknown_tensor_names = set(tensor_descriptors) - set(_TENSOR_NAMES)
+        if unknown_tensor_names:
+            raise RouteTraceValidationError(
+                f"route trace contains unknown logical tensors: {sorted(unknown_tensor_names)}"
+            )
+        expected_container_names = {_MANIFEST_TENSOR} | {
+            f"tensor.{name}" for name in tensor_descriptors
+        }
+        if set(tensors) != expected_container_names:
+            raise RouteTraceValidationError(
+                "route trace container tensor names do not match the manifest"
+            )
+        decoded = {
+            name: _decode_tensor(name, descriptor, tensors[f"tensor.{name}"])
+            for name, descriptor in tensor_descriptors.items()
+        }
+        return RouteTraceV0(
+            identity=RouteIdentityV0.from_dict(manifest["identity"]),
+            router_schema=RouterSchemaV0.from_dict(manifest["router_schema"]),
+            token_layout=RouteTokenLayoutV0.from_dict(manifest["token_layout"]),
+            level=_parse_enum(RouteTraceLevel, "level", manifest["level"]),
+            topk_ids=decoded.get("topk_ids"),
+            selected_weights=decoded.get("selected_weights"),
+            topk_margin=decoded.get("topk_margin"),
+            valid_mask=decoded.get("valid_mask"),
+        )

--- a/astrai/trainer/train_callback.py
+++ b/astrai/trainer/train_callback.py
@@ -15,6 +15,13 @@ from torch.utils.checkpoint import checkpoint as torch_checkpoint
 from tqdm import tqdm
 
 from astrai.factory import BaseFactory
+from astrai.moe import (
+    RecomputeRouteMismatchError,
+    RouteCheckpointPairV0,
+    RouteRecomputeDiagnosticsV0,
+    RouteRecomputeSummaryV0,
+    synchronize_route_recompute_summary,
+)
 from astrai.parallel import only_on_rank
 from astrai.parallel.setup import get_current_device
 from astrai.serialization import Checkpoint
@@ -126,18 +133,55 @@ class GradientCheckpointingCallback(TrainCallback):
 
     Args:
         modules: Module types to apply checkpointing to.
+        route_validation: ``"off"`` preserves the existing checkpoint path,
+            ``"record"`` publishes diagnostics, and ``"error"`` also aborts
+            before the optimizer step if a route differs or is incomplete.
     """
 
-    def __init__(self, modules: Optional[List[type]] = None):
+    _ROUTE_VALIDATION_MODES = frozenset(("off", "record", "error"))
+
+    def __init__(
+        self,
+        modules: Optional[List[type]] = None,
+        route_validation: str = "off",
+    ):
+        if route_validation not in self._ROUTE_VALIDATION_MODES:
+            raise ValueError(
+                "route_validation must be one of "
+                f"{sorted(self._ROUTE_VALIDATION_MODES)}, got {route_validation!r}"
+            )
         self.modules = tuple(modules) if modules else ()
+        self.route_validation = route_validation
+        self.route_diagnostics = RouteRecomputeDiagnosticsV0()
+        self.last_route_summary = RouteRecomputeSummaryV0()
+
+    def _checkpoint_forward(self, fn, *args, **kwargs):
+        if self.route_validation == "off":
+            return torch_checkpoint(fn, *args, use_reentrant=False, **kwargs)
+
+        pair = RouteCheckpointPairV0(self.route_diagnostics)
+
+        def observed_forward(*inner_args, **inner_kwargs):
+            output = fn(*inner_args, **inner_kwargs)
+            pair.observe(output)
+            return output
+
+        # Full recomputation is required so the observer after ``fn`` always
+        # sees the second route. This changes work only in the opt-in modes.
+        return torch_checkpoint(
+            observed_forward,
+            *args,
+            use_reentrant=False,
+            context_fn=pair.context_fn,
+            early_stop=False,
+            **kwargs,
+        )
 
     def _enable(self, module: nn.Module):
         if self.modules and isinstance(module, self.modules):
             fn = module.forward
             module._original_forward = fn
-            module.forward = lambda *a, **kw: torch_checkpoint(
-                fn, *a, use_reentrant=False, **kw
-            )
+            module.forward = lambda *a, **kw: self._checkpoint_forward(fn, *a, **kw)
 
     @staticmethod
     def _disable(module: nn.Module):
@@ -148,8 +192,47 @@ class GradientCheckpointingCallback(TrainCallback):
     def on_train_begin(self, context: TrainContext):
         if not self.modules:
             return
+        self.route_diagnostics.reset()
+        self.last_route_summary = RouteRecomputeSummaryV0()
         context.model.apply(self._enable)
-        logger.info("Gradient checkpointing enabled")
+        logger.info(
+            "Gradient checkpointing enabled (route validation: %s)",
+            self.route_validation,
+        )
+
+    def on_batch_begin(self, context: TrainContext):
+        _ = context
+        if self.route_validation != "off":
+            self.route_diagnostics.reset()
+
+    def on_batch_end(self, context: TrainContext):
+        if self.route_validation == "off":
+            return
+        local_summary = self.route_diagnostics.snapshot()
+        summary = synchronize_route_recompute_summary(
+            local_summary,
+            device=(
+                get_current_device()
+                if dist.is_available() and dist.is_initialized()
+                else None
+            ),
+        )
+        self.last_route_summary = summary
+        context.metrics.update(summary.to_metrics())
+        if not summary.has_failure:
+            return
+
+        message = (
+            "MoE route mismatch across checkpoint recomputation: "
+            f"mismatch_pairs={summary.mismatch_pair_count}, "
+            f"invalid_pairs={summary.invalid_pair_count}, "
+            f"unrecomputed_pairs={summary.unrecomputed_pair_count}, "
+            f"rank_inconsistent={summary.rank_observation_inconsistent}"
+        )
+        if self.route_validation == "error":
+            raise RecomputeRouteMismatchError(message)
+        if context.rank == 0:
+            logger.warning(message)
 
     def on_train_end(self, context: TrainContext):
         context.model.apply(self._disable)

--- a/astrai/trainer/trainer.py
+++ b/astrai/trainer/trainer.py
@@ -34,6 +34,7 @@ class Trainer:
             CallbackFactory.create(
                 "gradient_checkpointing",
                 modules=cfg.gradient_checkpointing_modules,
+                route_validation=cfg.gradient_checkpointing_route_validation,
             ),
             CallbackFactory.create(
                 "checkpoint",

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -6,6 +6,8 @@
 - [Module Overview](#module-overview) — Component inventory per module
 - [Design Patterns](#design-patterns) — 16 documented patterns with classes
 - [Core Relationships](#core-relationships) — 11 key inter-component relationships
+- [MoE route trace contract](route_trace.md) — versioned behavior identity,
+  safe serialization, and diagnostics
 
 ## Class Diagram
 

--- a/docs/developer/route_trace.md
+++ b/docs/developer/route_trace.md
@@ -1,0 +1,178 @@
+# Versioned MoE route trace contract
+
+`astrai.moe` defines `RouteTraceV0`, a compact behavior artifact for one
+contiguous token span. The contract is intentionally separate from model
+capture, rollout transport, expert dispatch, replay, and GRPO admission. Merely
+importing or constructing these objects does not change a forward pass or the
+training objective.
+
+## Identity and semantics
+
+A trace is interpretable only when all four components agree:
+
+- `RouteIdentityV0` binds `policy_version`, model/checkpoint revisions, router
+  and load-controller versions, and the router schema digest.
+- `RouterSchemaV0` binds layer/expert/top-k geometry, EP world size, score and
+  selected-weight semantics, expert and token ordering, padding, backend/kernel
+  semantics, and a content-addressed parallel layout.
+- `RouteTokenLayoutV0` identifies one sample, its full sequence and prompt
+  boundaries, and the captured contiguous prompt/response span.
+- `RouteTraceLevel` states whether the payload carries IDs only or IDs plus
+  selected weights and top-k margin.
+
+`RouterSchemaV0.fingerprint` is canonical JSON SHA-256. A trace whose identity
+does not contain that exact digest is rejected at construction and decode time.
+Consumers call `require_compatible_route_trace(...)` with their expected
+identity, schema, token span, and minimum payload level. Every field is compared
+exactly; there is no silent fallback for an unknown version or semantic field.
+
+## Tensor layout
+
+One trace represents one sample span:
+
+```text
+topk_ids          [tokens, moe_layers, top_k]
+selected_weights  [tokens, moe_layers, top_k]  optional
+topk_margin       [tokens, moe_layers]         optional
+valid_mask        [tokens]                     optional
+```
+
+IDs use the narrowest unsigned storage capable of representing all experts:
+
+```text
+num_experts <= 256    -> uint8
+num_experts <= 65536  -> uint16
+otherwise             -> uint32
+```
+
+Use `pack_route_ids(...)` to range-check and compact an integer tensor. Valid
+top-k rows must contain unique in-range experts. Invalid/padded rows must be
+canonical zeros, making their serialized bytes deterministic and preventing
+uninitialized padding from becoming part of behavior identity.
+
+`IDS_WEIGHTS_MARGIN` requires both optional floating tensors. Selected weights
+must be detached, finite, non-negative, and conform to the declared
+`full-softmax-selected` or `selected-renormalized` semantics. Margins are the
+non-negative top-k versus top-(k+1) score gap. The helper
+`compute_topk_margin(...)` computes this diagnostic after an explicit FP32
+conversion, including for BF16 near ties.
+
+## Safe serialization
+
+`RouteTraceCodecV0.dumps()` produces bytes suitable for an async rollout
+buffer. It does not use pickle. The outer container is safetensors; a strict
+canonical JSON manifest describes each logical tensor's dtype, shape, byte
+count, and SHA-256. Unsigned types unsupported by older safetensors releases
+are encoded as checked raw `uint8` buffers. The v0 wire format records and
+requires little-endian tensor bytes rather than silently interpreting a payload
+with the host's native byte order.
+
+`RouteTraceCodecV0.loads()` returns detached CPU tensors and rejects:
+
+- unknown/missing manifest or tensor fields;
+- unknown codec or schema versions;
+- malformed identity, schema, or token boundaries;
+- tensor-name, dtype, shape, byte-count, or checksum mismatch;
+- unsupported byte order, sparse/meta tensors, or non-canonical negative zero;
+- payloads above the caller's byte budget;
+- any trace invariant that construction would reject.
+
+The codec digest is available as `trace.artifact_digest`. Artifact storage or
+transport should retain that digest together with the policy/checkpoint
+identity, but those integrations belong in follow-up changes.
+
+## Codec microbenchmark
+
+The repository includes a deterministic serialization-only benchmark:
+
+```bash
+python scripts/benchmark_route_trace_codec.py \
+  --tokens 8192 --layers 40 --top-k 22 --num-experts 512 \
+  --level ids --device cpu --warmups 5 --repeats 50
+```
+
+The JSON output separates logical tensor bytes, wire bytes, and an int64-ID
+baseline, and reports serialize/deserialize latency. Construction happens
+outside the timed region. The benchmark does not measure model capture, D2H
+overlap, rollout transport, replay, training throughput, or end-to-end memory.
+
+## Diagnostics only
+
+`compare_route_traces(...)` requires exact router semantics, token layout,
+validity mask, and device while allowing behavior/current versions to differ.
+It reports:
+
+- ordered top-k equality;
+- unordered expert-set overlap and flip fraction;
+- sparse selected-weight L1 shift when both traces carry weights;
+- behavior margin mean and fragile-position fraction when margin is available.
+
+Missing optional data produces `None`, never a fabricated zero. Empty valid
+populations, mismatched layouts, and requested margin diagnostics without
+margins fail closed. These scalars are observations only; this module never
+rejects, downweights, or replays a rollout.
+
+## Example
+
+```python
+import torch
+
+from astrai.moe import (
+    PaddingLayout,
+    RouteIdentityV0,
+    RouterSchemaV0,
+    RouteTokenLayoutV0,
+    RouteTraceCodecV0,
+    RouteTraceLevel,
+    RouteTraceV0,
+    SelectedWeightSemantics,
+    TokenSpanKind,
+    canonical_json_digest,
+    pack_route_ids,
+)
+
+schema = RouterSchemaV0(
+    num_moe_layers=2,
+    num_experts=64,
+    top_k=2,
+    expert_parallel_world_size=1,
+    score_function="softmax-fp32-before-topk",
+    score_dtype="float32",
+    expert_id_ordering="score-descending-stable-index",
+    selected_weight_semantics=SelectedWeightSemantics.SELECTED_RENORMALIZED,
+    token_ordering="single-sequence-token-major",
+    padding_layout=PaddingLayout.NONE,
+    backend="astrai-torch",
+    kernel_semantics_version="torch-topk-v1",
+    parallel_layout_hash=canonical_json_digest({"placement": "all-local"}),
+)
+identity = RouteIdentityV0(
+    policy_version=12,
+    model_revision="model-12",
+    router_state_version=12,
+    checkpoint_revision="checkpoint-12",
+    router_schema_hash=schema.fingerprint,
+)
+layout = RouteTokenLayoutV0(
+    sample_id="opaque-sample-id",
+    sequence_token_count=2,
+    prompt_token_count=0,
+    token_offset=0,
+    token_count=2,
+    span_kind=TokenSpanKind.FULL_SEQUENCE,
+)
+trace = RouteTraceV0(
+    identity=identity,
+    router_schema=schema,
+    token_layout=layout,
+    level=RouteTraceLevel.IDS,
+    topk_ids=pack_route_ids(torch.tensor([[[0, 1]], [[2, 3]]]), 64),
+)
+wire_bytes = RouteTraceCodecV0.dumps(trace)
+restored = RouteTraceCodecV0.loads(wire_bytes)
+```
+
+Before adding capture or replay, a follow-up must define how model revision,
+checkpoint revision, router-state version, kernel semantics, token boundaries,
+and parallel-layout digest are sourced atomically. That integration must remain
+opt-in and preserve the current model path when disabled.

--- a/docs/developer/route_trace.md
+++ b/docs/developer/route_trace.md
@@ -176,3 +176,47 @@ Before adding capture or replay, a follow-up must define how model revision,
 checkpoint revision, router-state version, kernel semantics, token boundaries,
 and parallel-layout digest are sourced atomically. That integration must remain
 opt-in and preserve the current model path when disabled.
+
+## Checkpoint-recompute route validation
+
+`astrai.moe.compare_recompute_routes(...)` compares ordered top-k expert IDs
+from the original forward and activation-checkpoint recomputation. It
+normalizes integer storage to a canonical CPU representation and reports
+content hashes plus mismatched layer, token-row, and top-k-slot counts. Shape,
+negative-ID, duplicate-ID, and missing-layer ambiguities fail closed.
+
+`GradientCheckpointingCallback` can attach one observer to each checkpoint
+invocation. Its `route_validation` modes are:
+
+- `off` (default): the existing non-reentrant checkpoint path is unchanged;
+- `record`: compare routes and publish bounded counters into training metrics;
+- `error`: publish the same counters and stop before the optimizer step if a
+  mismatch, malformed observation, missing recomputation, or cross-rank
+  observation-count inconsistency is present.
+
+The observer uses the checkpoint API's separate forward/recompute contexts,
+so concurrent or reverse-order backward graphs are paired by invocation rather
+than by a global call counter. It stores only detached CPU top-k IDs until the
+matching recomputation and then releases them. In distributed training, small
+integer summaries are gathered on the initialized process group and every rank
+receives the same decision. This is generic in world size; tests exercise two
+and four Gloo ranks.
+
+The opt-in path disables checkpoint early-stop for the wrapped invocation so
+the post-forward observer always receives the recomputed route. It is therefore
+incompatible with `torch.compile` in this version and has measurable overhead.
+It does not select or replay experts and does not change gradients when routes
+match.
+
+Measure a local MoE forward/backward against the existing checkpoint path with:
+
+```bash
+python scripts/benchmark_moe_recompute_validation.py \
+  --tokens 128 --dim 128 --dim-ffn 256 \
+  --num-experts 8 --top-k 2 --device cpu \
+  --warmups 3 --repeats 10
+```
+
+The report includes route hashes, mismatch counters, output/gradient parity,
+and paired-path latency. It excludes route replay, optimizer work, distributed
+training throughput, and end-to-end model performance.

--- a/docs/guides/training.md
+++ b/docs/guides/training.md
@@ -219,6 +219,25 @@ config = TrainConfig(..., gradient_checkpointing_modules=[DecoderBlock])
 
 Callback wraps each `DecoderBlock.forward` with `torch.utils.checkpoint.checkpoint(use_reentrant=False)`, compatible with `torch.compile`. Uses `nn.Module.apply()` for traversal — works through DDP wrappers without manual unwrap. Empty list (default) means no-op.
 
+For opt-in MoE diagnostics, set
+`gradient_checkpointing_route_validation="record"` to compare the ordered
+top-k route from each original forward with its recomputation. Use `"error"`
+to stop before the optimizer step when any rank reports a mismatch, invalid
+observation, or missing recomputation:
+
+```python
+config = TrainConfig(
+    ...,
+    gradient_checkpointing_modules=[DecoderBlock],
+    gradient_checkpointing_route_validation="error",
+)
+```
+
+The default is `"off"` and preserves the existing callback. Route validation
+forces complete recomputation so the second route can be observed; it cannot
+currently be combined with `torch.compile`. It records bounded counters only
+and does not replay or alter expert choices.
+
 ## Checkpoint
 
 ```

--- a/scripts/benchmark_moe_recompute_validation.py
+++ b/scripts/benchmark_moe_recompute_validation.py
@@ -55,9 +55,9 @@ def _make_model(
         n_layers=2,
     )
     model.apply(
-        lambda module: module.reset_parameters()
-        if hasattr(module, "reset_parameters")
-        else None
+        lambda module: (
+            module.reset_parameters() if hasattr(module, "reset_parameters") else None
+        )
     )
     return model.to(device=device)
 

--- a/scripts/benchmark_moe_recompute_validation.py
+++ b/scripts/benchmark_moe_recompute_validation.py
@@ -1,0 +1,300 @@
+"""Measure opt-in checkpoint route validation and verify gradient parity.
+
+This microbenchmark compares the existing non-reentrant activation-checkpoint
+path with the same path plus route observation. It uses one local DeepSeekMoE
+module and makes no distributed-training or end-to-end throughput claim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import math
+import statistics
+import time
+from pathlib import Path
+
+import torch
+
+from astrai.model.components.mlp import DeepSeekMoE
+from astrai.trainer.train_callback import GradientCheckpointingCallback
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    ordered = sorted(values)
+    return ordered[max(0, math.ceil(percentile * len(ordered)) - 1)]
+
+
+def _synchronize(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def _make_model(
+    *,
+    dim: int,
+    dim_ffn: int,
+    num_experts: int,
+    top_k: int,
+    device: torch.device,
+) -> DeepSeekMoE:
+    model = DeepSeekMoE(
+        dim=dim,
+        dim_ffn=dim_ffn,
+        n_routed_experts=num_experts,
+        n_shared_experts=1,
+        n_activated_experts=top_k,
+        n_layers=2,
+    )
+    model.apply(
+        lambda module: module.reset_parameters()
+        if hasattr(module, "reset_parameters")
+        else None
+    )
+    return model.to(device=device)
+
+
+def _run_once(model, callback, source, device):
+    model.zero_grad(set_to_none=True)
+    callback.route_diagnostics.reset()
+    value = source.detach().clone().requires_grad_(True)
+    _synchronize(device)
+    started = time.perf_counter_ns()
+    output = model(value)
+    loss = output["hidden_states"].float().square().mean()
+    loss = loss + 0.01 * output["aux_loss"].float()
+    loss.backward()
+    _synchronize(device)
+    elapsed_us = (time.perf_counter_ns() - started) / 1000
+    gradients = {
+        "input": None if value.grad is None else value.grad.detach().cpu().clone()
+    }
+    gradients.update(
+        {
+            name: (
+                None
+                if parameter.grad is None
+                else parameter.grad.detach().cpu().clone()
+            )
+            for name, parameter in model.named_parameters()
+        }
+    )
+    return elapsed_us, output["hidden_states"].detach().cpu(), gradients
+
+
+def _gradient_parity(reference, candidate, *, rtol: float, atol: float):
+    if reference.keys() != candidate.keys():
+        raise RuntimeError("gradient sets have different parameter names")
+    max_abs_diff = 0.0
+    allclose = True
+    compared_tensor_count = 0
+    absent_tensor_count = 0
+    presence_mismatch_count = 0
+    for name in reference:
+        expected = reference[name]
+        actual = candidate[name]
+        if expected is None or actual is None:
+            if expected is None and actual is None:
+                absent_tensor_count += 1
+            else:
+                presence_mismatch_count += 1
+                allclose = False
+            continue
+        compared_tensor_count += 1
+        expected = expected.float()
+        actual = actual.float()
+        if expected.shape != actual.shape:
+            raise RuntimeError(f"gradient shape changed for {name}")
+        if expected.numel():
+            max_abs_diff = max(
+                max_abs_diff, float((expected - actual).abs().max().item())
+            )
+        allclose = allclose and torch.allclose(expected, actual, rtol=rtol, atol=atol)
+    return {
+        "absent_tensor_count": absent_tensor_count,
+        "allclose": allclose,
+        "atol": atol,
+        "compared_tensor_count": compared_tensor_count,
+        "max_abs_diff": max_abs_diff,
+        "presence_mismatch_count": presence_mismatch_count,
+        "rtol": rtol,
+        "tensor_count": len(reference),
+    }
+
+
+def run_benchmark(
+    *,
+    tokens: int,
+    dim: int,
+    dim_ffn: int,
+    num_experts: int,
+    top_k: int,
+    device: torch.device,
+    warmups: int,
+    repeats: int,
+) -> dict:
+    """Return checkpoint latency, route identity, and gradient parity."""
+    if min(tokens, dim, dim_ffn, num_experts, top_k, repeats) < 1:
+        raise ValueError("dimensions and repeats must be positive")
+    if top_k > num_experts:
+        raise ValueError("top_k must not exceed num_experts")
+    if warmups < 0:
+        raise ValueError("warmups must be non-negative")
+
+    torch.manual_seed(20260903)
+    reference_model = _make_model(
+        dim=dim,
+        dim_ffn=dim_ffn,
+        num_experts=num_experts,
+        top_k=top_k,
+        device=device,
+    ).train()
+    validated_model = copy.deepcopy(reference_model).train()
+    source = torch.randn(tokens, dim, dtype=torch.float32, device=device)
+    reference_callback = GradientCheckpointingCallback(
+        modules=[DeepSeekMoE], route_validation="off"
+    )
+    validated_callback = GradientCheckpointingCallback(
+        modules=[DeepSeekMoE], route_validation="record"
+    )
+    reference_callback._enable(reference_model)
+    validated_callback._enable(validated_model)
+
+    reference_times = []
+    validated_times = []
+    reference_output = None
+    validated_output = None
+    reference_gradients = None
+    validated_gradients = None
+    try:
+        for _ in range(warmups):
+            _run_once(reference_model, reference_callback, source, device)
+            _run_once(validated_model, validated_callback, source, device)
+        for repeat in range(repeats):
+            modes = (
+                (
+                    (reference_model, reference_callback, reference_times),
+                    (validated_model, validated_callback, validated_times),
+                )
+                if repeat % 2 == 0
+                else (
+                    (validated_model, validated_callback, validated_times),
+                    (reference_model, reference_callback, reference_times),
+                )
+            )
+            for model, callback, timings in modes:
+                elapsed, output, gradients = _run_once(model, callback, source, device)
+                timings.append(elapsed)
+                if callback is reference_callback:
+                    reference_output = output
+                    reference_gradients = gradients
+                else:
+                    validated_output = output
+                    validated_gradients = gradients
+    finally:
+        reference_callback._disable(reference_model)
+        validated_callback._disable(validated_model)
+
+    if (
+        reference_output is None
+        or validated_output is None
+        or reference_gradients is None
+        or validated_gradients is None
+    ):
+        raise RuntimeError("benchmark did not produce comparison outputs")
+    route_summary = validated_callback.route_diagnostics.snapshot()
+    route_report = validated_callback.route_diagnostics.last_report
+    if route_report is None or route_summary.has_failure:
+        raise RuntimeError("validated checkpoint did not reproduce its forward route")
+
+    reference_median = statistics.median(reference_times)
+    validated_median = statistics.median(validated_times)
+    output_max_abs_diff = float(
+        (reference_output.float() - validated_output.float()).abs().max().item()
+    )
+    return {
+        "benchmark": "astrai-moe-checkpoint-route-validation-v0",
+        "device": str(device),
+        "gradient_parity": _gradient_parity(
+            reference_gradients,
+            validated_gradients,
+            rtol=1e-5,
+            atol=1e-6,
+        ),
+        "latency_us": {
+            "checkpoint_only_median": reference_median,
+            "checkpoint_only_p95": _percentile(reference_times, 0.95),
+            "route_validation_median": validated_median,
+            "route_validation_p95": _percentile(validated_times, 0.95),
+            "validation_overhead_percent": 100
+            * (validated_median - reference_median)
+            / reference_median,
+            "validation_ratio": validated_median / reference_median,
+        },
+        "output_max_abs_diff": output_max_abs_diff,
+        "parameters": {
+            "dim": dim,
+            "dim_ffn": dim_ffn,
+            "num_experts": num_experts,
+            "repeats": repeats,
+            "tokens": tokens,
+            "top_k": top_k,
+            "warmups": warmups,
+        },
+        "route_pair": route_report.to_dict(),
+        "route_summary": route_summary.to_dict(),
+        "schema_version": 1,
+        "scope": (
+            "one local MoE forward/backward; excludes distributed training, "
+            "route replay, optimizer work, and end-to-end throughput"
+        ),
+        "torch_version": torch.__version__,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tokens", type=_positive_int, default=128)
+    parser.add_argument("--dim", type=_positive_int, default=128)
+    parser.add_argument("--dim-ffn", type=_positive_int, default=256)
+    parser.add_argument("--num-experts", type=_positive_int, default=8)
+    parser.add_argument("--top-k", type=_positive_int, default=2)
+    parser.add_argument("--device", choices=("cpu", "cuda"), default="cpu")
+    parser.add_argument("--warmups", type=int, default=3)
+    parser.add_argument("--repeats", type=_positive_int, default=10)
+    parser.add_argument("--output-json", type=Path)
+    args = parser.parse_args()
+    if args.warmups < 0:
+        parser.error("--warmups must be non-negative")
+    if args.top_k > args.num_experts:
+        parser.error("--top-k must not exceed --num-experts")
+    if args.device == "cuda" and not torch.cuda.is_available():
+        parser.error("--device cuda requires an available CUDA device")
+
+    report = run_benchmark(
+        tokens=args.tokens,
+        dim=args.dim,
+        dim_ffn=args.dim_ffn,
+        num_experts=args.num_experts,
+        top_k=args.top_k,
+        device=torch.device(args.device),
+        warmups=args.warmups,
+        repeats=args.repeats,
+    )
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_route_trace_codec.py
+++ b/scripts/benchmark_route_trace_codec.py
@@ -1,0 +1,237 @@
+"""Measure RouteTraceV0 codec cost without changing model execution.
+
+This is a serialization microbenchmark, not a capture, replay, training, or
+end-to-end performance benchmark. It emits enough geometry and byte accounting
+to compare compact ID tiers on a specific host.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import time
+from pathlib import Path
+
+import torch
+
+from astrai.moe import (
+    PaddingLayout,
+    RouteIdentityV0,
+    RouterSchemaV0,
+    RouteTokenLayoutV0,
+    RouteTraceCodecV0,
+    RouteTraceLevel,
+    RouteTraceV0,
+    SelectedWeightSemantics,
+    TokenSpanKind,
+    canonical_json_digest,
+    pack_route_ids,
+)
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    ordered = sorted(values)
+    index = max(0, math.ceil(percentile * len(ordered)) - 1)
+    return ordered[index]
+
+
+def _synchronize(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def build_trace(
+    *,
+    tokens: int,
+    layers: int,
+    top_k: int,
+    num_experts: int,
+    level: RouteTraceLevel,
+    device: torch.device,
+) -> RouteTraceV0:
+    """Build one deterministic, valid codec benchmark artifact."""
+    if min(tokens, layers, top_k, num_experts) < 1 or top_k > num_experts:
+        raise ValueError(
+            "tokens/layers/top_k/num_experts must be positive and top_k <= num_experts"
+        )
+    schema = RouterSchemaV0(
+        num_moe_layers=layers,
+        num_experts=num_experts,
+        top_k=top_k,
+        expert_parallel_world_size=1,
+        score_function="synthetic-softmax-fp32-before-topk",
+        score_dtype="float32",
+        expert_id_ordering="score-descending-stable-index",
+        selected_weight_semantics=SelectedWeightSemantics.SELECTED_RENORMALIZED,
+        token_ordering="single-sequence-token-major",
+        padding_layout=PaddingLayout.NONE,
+        backend="codec-benchmark",
+        kernel_semantics_version="synthetic-v0",
+        parallel_layout_hash=canonical_json_digest({"placement": "all-experts-local"}),
+    )
+    identity = RouteIdentityV0(
+        policy_version=0,
+        model_revision="synthetic-model",
+        router_state_version=0,
+        checkpoint_revision="synthetic-checkpoint",
+        router_schema_hash=schema.fingerprint,
+    )
+    token_layout = RouteTokenLayoutV0(
+        sample_id="codec-benchmark-sample",
+        sequence_token_count=tokens,
+        prompt_token_count=0,
+        token_offset=0,
+        token_count=tokens,
+        span_kind=TokenSpanKind.FULL_SEQUENCE,
+    )
+    row = torch.arange(top_k, dtype=torch.int64)
+    row_offsets = torch.arange(tokens * layers, dtype=torch.int64).reshape(
+        tokens, layers, 1
+    )
+    topk_ids = pack_route_ids((row + row_offsets) % num_experts, num_experts).to(device)
+    selected_weights = None
+    topk_margin = None
+    if level is RouteTraceLevel.IDS_WEIGHTS_MARGIN:
+        selected_weights = torch.full(
+            (tokens, layers, top_k),
+            1.0 / top_k,
+            dtype=torch.float16,
+            device=device,
+        )
+        topk_margin = torch.full(
+            (tokens, layers), 0.125, dtype=torch.float16, device=device
+        )
+    return RouteTraceV0(
+        identity=identity,
+        router_schema=schema,
+        token_layout=token_layout,
+        level=level,
+        topk_ids=topk_ids,
+        selected_weights=selected_weights,
+        topk_margin=topk_margin,
+    )
+
+
+def run_benchmark(
+    *,
+    tokens: int,
+    layers: int,
+    top_k: int,
+    num_experts: int,
+    level: RouteTraceLevel,
+    device: torch.device,
+    warmups: int,
+    repeats: int,
+) -> dict:
+    """Return deterministic byte accounting and measured codec latency."""
+    if warmups < 0 or repeats < 1:
+        raise ValueError("warmups must be non-negative and repeats must be positive")
+    trace = build_trace(
+        tokens=tokens,
+        layers=layers,
+        top_k=top_k,
+        num_experts=num_experts,
+        level=level,
+        device=device,
+    )
+    for _ in range(warmups):
+        RouteTraceCodecV0.loads(RouteTraceCodecV0.dumps(trace))
+
+    serialize_us = []
+    deserialize_us = []
+    blob = b""
+    restored = None
+    for _ in range(repeats):
+        _synchronize(device)
+        started = time.perf_counter_ns()
+        blob = RouteTraceCodecV0.dumps(trace)
+        _synchronize(device)
+        encoded = time.perf_counter_ns()
+        restored = RouteTraceCodecV0.loads(blob)
+        finished = time.perf_counter_ns()
+        serialize_us.append((encoded - started) / 1000)
+        deserialize_us.append((finished - encoded) / 1000)
+    assert restored is not None
+    if restored.artifact_digest != trace.artifact_digest:
+        raise RuntimeError("codec benchmark round-trip changed artifact identity")
+
+    return {
+        "schema_version": 1,
+        "benchmark": "astrai-route-trace-codec-v0",
+        "scope": "codec-only; excludes model capture, transport, replay, and training",
+        "device": str(device),
+        "torch_version": torch.__version__,
+        "parameters": {
+            "tokens": tokens,
+            "layers": layers,
+            "top_k": top_k,
+            "num_experts": num_experts,
+            "level": level.value,
+            "warmups": warmups,
+            "repeats": repeats,
+        },
+        "bytes": {
+            "logical_payload": trace.payload_nbytes,
+            "wire": len(blob),
+            "wire_per_token": len(blob) / tokens,
+            "int64_ids_only_baseline": tokens * layers * top_k * 8,
+        },
+        "latency_us": {
+            "serialize_median": statistics.median(serialize_us),
+            "serialize_p95": _percentile(serialize_us, 0.95),
+            "deserialize_median": statistics.median(deserialize_us),
+            "deserialize_p95": _percentile(deserialize_us, 0.95),
+        },
+        "artifact_digest": trace.artifact_digest,
+    }
+
+
+def main() -> None:
+    """Run the codec benchmark and emit one JSON report."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tokens", type=_positive_int, default=1024)
+    parser.add_argument("--layers", type=_positive_int, default=16)
+    parser.add_argument("--top-k", type=_positive_int, default=2)
+    parser.add_argument("--num-experts", type=_positive_int, default=64)
+    parser.add_argument(
+        "--level", choices=[level.value for level in RouteTraceLevel], default="ids"
+    )
+    parser.add_argument("--device", choices=("cpu", "cuda"), default="cpu")
+    parser.add_argument("--warmups", type=int, default=3)
+    parser.add_argument("--repeats", type=_positive_int, default=20)
+    parser.add_argument("--output-json", type=Path)
+    args = parser.parse_args()
+    if args.warmups < 0:
+        parser.error("--warmups must be non-negative")
+    if args.top_k > args.num_experts:
+        parser.error("--top-k must not exceed --num-experts")
+    if args.device == "cuda" and not torch.cuda.is_available():
+        parser.error("--device cuda requires an available CUDA device")
+    report = run_benchmark(
+        tokens=args.tokens,
+        layers=args.layers,
+        top_k=args.top_k,
+        num_experts=args.num_experts,
+        level=RouteTraceLevel(args.level),
+        device=torch.device(args.device),
+        warmups=args.warmups,
+        repeats=args.repeats,
+    )
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/moe/test_recompute.py
+++ b/tests/moe/test_recompute.py
@@ -1,0 +1,222 @@
+"""Tests for forward/checkpoint-recompute route diagnostics."""
+
+from dataclasses import replace
+
+import pytest
+import torch
+
+from astrai.moe import (
+    ROUTE_RECOMPUTE_SCHEMA_VERSION,
+    RecomputeRouteValidationError,
+    RouteCheckpointPairV0,
+    RouteRecomputeDiagnosticsV0,
+    RouteRecomputeSummaryV0,
+    compare_recompute_routes,
+    synchronize_route_recompute_summary,
+)
+from astrai.parallel import get_rank, get_world_size, spawn_parallel_fn
+
+
+def _route_layers():
+    return (
+        torch.tensor([[0, 1], [2, 3], [4, 5]], dtype=torch.int64),
+        torch.tensor([[[1, 2], [3, 4]]], dtype=torch.int64),
+    )
+
+
+def test_exact_report_is_content_addressed_and_dtype_normalized():
+    forward = _route_layers()
+    recompute = tuple(layer.to(torch.int32) for layer in forward)
+
+    report = compare_recompute_routes(forward, recompute)
+
+    assert report.schema_version == ROUTE_RECOMPUTE_SCHEMA_VERSION
+    assert report.exact_match is True
+    assert report.forward_route_hash == report.recompute_route_hash
+    assert report.layer_count == 2
+    assert report.token_count == 5
+    assert report.slot_count == 10
+    assert report.mismatch_layer_count == 0
+    assert report.mismatch_token_count == 0
+    assert report.mismatch_slot_count == 0
+    assert report.to_dict()["exact_match"] is True
+
+
+def test_report_counts_ordered_slot_token_and_layer_mismatches():
+    forward = list(_route_layers())
+    recompute = [layer.clone() for layer in forward]
+    recompute[0][1, 0] = 6
+    recompute[1][0, 1] = recompute[1][0, 1].flip(0)
+
+    report = compare_recompute_routes(forward, recompute)
+
+    assert report.exact_match is False
+    assert report.forward_route_hash != report.recompute_route_hash
+    assert report.mismatch_layer_count == 2
+    assert report.mismatch_token_count == 2
+    assert report.mismatch_slot_count == 3
+
+
+@pytest.mark.parametrize(
+    ("forward", "recompute", "message"),
+    [
+        (_route_layers(), _route_layers()[:1], "layer counts"),
+        (
+            (torch.tensor([[0, 1]], dtype=torch.int64),),
+            (torch.tensor([[[0, 1]]], dtype=torch.int64),),
+            "shapes differ",
+        ),
+        (
+            (torch.tensor([[0.0, 1.0]]),),
+            (torch.tensor([[0, 1]]),),
+            "integer dtype",
+        ),
+        (
+            (torch.tensor([[-1, 1]]),),
+            (torch.tensor([[0, 1]]),),
+            "negative expert ID",
+        ),
+        (
+            (torch.tensor([[1, 1]]),),
+            (torch.tensor([[0, 1]]),),
+            "duplicate experts",
+        ),
+        ((), (), "at least one routed layer"),
+    ],
+)
+def test_compare_rejects_ambiguous_or_malformed_routes(forward, recompute, message):
+    with pytest.raises(RecomputeRouteValidationError, match=message):
+        compare_recompute_routes(forward, recompute)
+
+
+def test_report_and_summary_constructors_fail_closed():
+    report = compare_recompute_routes(_route_layers(), _route_layers())
+    with pytest.raises(RecomputeRouteValidationError, match="unsupported"):
+        replace(report, schema_version=1)
+    with pytest.raises(RecomputeRouteValidationError, match="hashes"):
+        replace(report, recompute_route_hash="0" * 64)
+    with pytest.raises(RecomputeRouteValidationError, match="must equal"):
+        RouteRecomputeSummaryV0(compared_pair_count=1)
+    with pytest.raises(RecomputeRouteValidationError, match="exceeds forward"):
+        RouteRecomputeSummaryV0(completed_forward_pair_count=1)
+    with pytest.raises(RecomputeRouteValidationError, match="zero or one"):
+        RouteRecomputeSummaryV0(rank_observation_inconsistent=2)
+
+
+def test_checkpoint_pair_records_mismatch_without_retaining_route_tensors():
+    diagnostics = RouteRecomputeDiagnosticsV0()
+    pair = RouteCheckpointPairV0(diagnostics)
+    forward_context, recompute_context = pair.context_fn()
+    forward = _route_layers()[0]
+    recompute = forward.clone()
+    recompute[1, 0] = 6
+
+    with forward_context:
+        pair.observe({"router_stats": {"topk_indices": forward}})
+    with recompute_context:
+        pair.observe({"router_stats": {"topk_indices": recompute}})
+
+    summary = diagnostics.snapshot()
+    assert summary.forward_pair_count == 1
+    assert summary.completed_forward_pair_count == 1
+    assert summary.compared_pair_count == 1
+    assert summary.mismatch_pair_count == 1
+    assert summary.mismatch_token_count == 1
+    assert summary.unrecomputed_pair_count == 0
+    assert summary.has_failure is True
+    assert diagnostics.last_report is not None
+    assert diagnostics.last_report.mismatch_slot_count == 1
+
+
+def test_checkpoint_pair_ignores_dense_output_and_reports_incomplete_routes():
+    diagnostics = RouteRecomputeDiagnosticsV0()
+    dense_pair = RouteCheckpointPairV0(diagnostics)
+    forward_context, recompute_context = dense_pair.context_fn()
+    with forward_context:
+        dense_pair.observe({"router_stats": None})
+    with recompute_context:
+        dense_pair.observe({"router_stats": None})
+    assert diagnostics.snapshot() == RouteRecomputeSummaryV0()
+
+    routed_pair = RouteCheckpointPairV0(diagnostics)
+    forward_context, _ = routed_pair.context_fn()
+    with forward_context:
+        routed_pair.observe({"router_stats": {"topk_indices": _route_layers()[0]}})
+    summary = diagnostics.snapshot()
+    assert summary.unrecomputed_pair_count == 1
+    assert summary.has_failure is True
+
+    diagnostics.reset()
+    invalid_pair = RouteCheckpointPairV0(diagnostics)
+    forward_context, _ = invalid_pair.context_fn()
+    with forward_context:
+        invalid_pair.observe({"router_stats": {}})
+    summary = diagnostics.snapshot()
+    assert summary.forward_pair_count == 1
+    assert summary.completed_forward_pair_count == 1
+    assert summary.invalid_pair_count == 1
+    assert summary.unrecomputed_pair_count == 0
+    assert diagnostics.last_invalid_reason == (
+        "router_stats[0] must contain topk_indices"
+    )
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_summary_merge_marks_only_inconsistent_rank_geometry(world_size):
+    exact = RouteRecomputeSummaryV0(
+        forward_pair_count=1,
+        completed_forward_pair_count=1,
+        compared_pair_count=1,
+        exact_pair_count=1,
+        compared_layer_count=2,
+        compared_token_count=5,
+        compared_slot_count=10,
+    )
+    summaries = [exact for _ in range(world_size)]
+    merged = RouteRecomputeSummaryV0.merge(summaries)
+    assert merged.forward_pair_count == world_size
+    assert merged.compared_pair_count == world_size
+    assert merged.rank_observation_inconsistent == 0
+
+    summaries[-1] = RouteRecomputeSummaryV0()
+    merged = RouteRecomputeSummaryV0.merge(summaries)
+    assert merged.rank_observation_inconsistent == 1
+    assert merged.has_failure is True
+
+
+def _distributed_summary_worker():
+    rank = get_rank()
+    world_size = get_world_size()
+    forward = _route_layers()[0]
+    recompute = forward.clone()
+    if rank % 2:
+        recompute[0, 0] = 6
+    diagnostics = RouteRecomputeDiagnosticsV0()
+    diagnostics.record_forward_pair()
+    diagnostics.record_report(compare_recompute_routes(forward, recompute))
+
+    merged = synchronize_route_recompute_summary(diagnostics.snapshot(), device="cpu")
+
+    assert merged.forward_pair_count == world_size
+    assert merged.compared_pair_count == world_size
+    assert merged.exact_pair_count == world_size - world_size // 2
+    assert merged.mismatch_pair_count == world_size // 2
+    assert merged.mismatch_token_count == world_size // 2
+    assert merged.rank_observation_inconsistent == 0
+
+    uneven_local = RouteRecomputeSummaryV0() if rank == 0 else diagnostics.snapshot()
+    uneven_merged = synchronize_route_recompute_summary(uneven_local, device="cpu")
+    assert uneven_merged.forward_pair_count == world_size - 1
+    assert uneven_merged.compared_pair_count == world_size - 1
+    assert uneven_merged.rank_observation_inconsistent == 1
+    assert uneven_merged.has_failure is True
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_summary_synchronizes_on_real_gloo_process_groups(world_size):
+    spawn_parallel_fn(
+        _distributed_summary_worker,
+        world_size=world_size,
+        backend="gloo",
+        device_type="cpu",
+    )

--- a/tests/moe/test_recompute_benchmark.py
+++ b/tests/moe/test_recompute_benchmark.py
@@ -1,0 +1,65 @@
+"""Tests for the MoE checkpoint route-validation microbenchmark."""
+
+import pytest
+import torch
+
+from scripts.benchmark_moe_recompute_validation import run_benchmark
+
+
+def test_recompute_benchmark_reports_route_and_gradient_parity():
+    report = run_benchmark(
+        tokens=4,
+        dim=8,
+        dim_ffn=16,
+        num_experts=4,
+        top_k=2,
+        device=torch.device("cpu"),
+        warmups=0,
+        repeats=1,
+    )
+
+    assert report["schema_version"] == 1
+    assert report["benchmark"] == "astrai-moe-checkpoint-route-validation-v0"
+    assert report["route_pair"]["exact_match"] is True
+    assert report["route_summary"]["has_failure"] is False
+    assert report["gradient_parity"]["allclose"] is True
+    assert report["gradient_parity"]["max_abs_diff"] == pytest.approx(0.0)
+    assert report["output_max_abs_diff"] == pytest.approx(0.0)
+    assert report["latency_us"]["checkpoint_only_median"] > 0
+    assert report["latency_us"]["route_validation_median"] > 0
+
+
+def test_recompute_benchmark_rejects_invalid_geometry():
+    with pytest.raises(ValueError, match="top_k"):
+        run_benchmark(
+            tokens=1,
+            dim=2,
+            dim_ffn=4,
+            num_experts=2,
+            top_k=3,
+            device=torch.device("cpu"),
+            warmups=0,
+            repeats=1,
+        )
+
+
+def test_recompute_benchmark_handles_unselected_expert_gradients():
+    report = run_benchmark(
+        tokens=1,
+        dim=4,
+        dim_ffn=8,
+        num_experts=8,
+        top_k=1,
+        device=torch.device("cpu"),
+        warmups=0,
+        repeats=1,
+    )
+
+    parity = report["gradient_parity"]
+    assert parity["allclose"] is True
+    assert parity["absent_tensor_count"] > 0
+    assert parity["presence_mismatch_count"] == 0
+    assert (
+        parity["compared_tensor_count"] + parity["absent_tensor_count"]
+        == parity["tensor_count"]
+    )

--- a/tests/moe/test_route_metrics.py
+++ b/tests/moe/test_route_metrics.py
@@ -1,0 +1,182 @@
+"""Tests for pure route-alignment and near-tie diagnostics."""
+
+from dataclasses import replace
+
+import pytest
+import torch
+
+from astrai.moe import (
+    PaddingLayout,
+    RouteIdentityV0,
+    RouterSchemaV0,
+    RouteTokenLayoutV0,
+    RouteTraceLevel,
+    RouteTraceV0,
+    RouteTraceValidationError,
+    SelectedWeightSemantics,
+    TokenSpanKind,
+    canonical_json_digest,
+    compare_route_traces,
+    compute_topk_margin,
+    pack_route_ids,
+)
+
+
+def _metric_trace(
+    ids, weights=None, margins=None, *, policy_version=0, valid_mask=None
+):
+    padding_layout = (
+        PaddingLayout.EXPLICIT_MASK if valid_mask is not None else PaddingLayout.NONE
+    )
+    schema = RouterSchemaV0(
+        num_moe_layers=1,
+        num_experts=8,
+        top_k=2,
+        expert_parallel_world_size=1,
+        score_function="softmax-fp32-before-topk",
+        score_dtype="float32",
+        expert_id_ordering="score-descending-stable-index",
+        selected_weight_semantics=SelectedWeightSemantics.SELECTED_RENORMALIZED,
+        token_ordering="single-sequence-token-major",
+        padding_layout=padding_layout,
+        backend="unit-test",
+        kernel_semantics_version="torch-topk-v1",
+        parallel_layout_hash=canonical_json_digest({"placement": "local"}),
+    )
+    identity = RouteIdentityV0(
+        policy_version=policy_version,
+        model_revision=f"model-{policy_version}",
+        router_state_version=policy_version,
+        checkpoint_revision=f"checkpoint-{policy_version}",
+        router_schema_hash=schema.fingerprint,
+    )
+    token_layout = RouteTokenLayoutV0(
+        sample_id="sample",
+        sequence_token_count=2,
+        prompt_token_count=0,
+        token_offset=0,
+        token_count=2,
+        span_kind=TokenSpanKind.FULL_SEQUENCE,
+    )
+    level = (
+        RouteTraceLevel.IDS_WEIGHTS_MARGIN
+        if weights is not None and margins is not None
+        else RouteTraceLevel.IDS
+    )
+    mask_tensor = (
+        torch.tensor(valid_mask, dtype=torch.bool) if valid_mask is not None else None
+    )
+    topk_ids = pack_route_ids(torch.tensor(ids).reshape(2, 1, 2), schema.num_experts)
+    if mask_tensor is not None:
+        topk_ids[~mask_tensor] = 0
+    return RouteTraceV0(
+        identity=identity,
+        router_schema=schema,
+        token_layout=token_layout,
+        level=level,
+        topk_ids=topk_ids,
+        selected_weights=(
+            torch.tensor(weights, dtype=torch.float16).reshape(2, 1, 2)
+            if weights is not None
+            else None
+        ),
+        topk_margin=(
+            torch.tensor(margins, dtype=torch.float16).reshape(2, 1)
+            if margins is not None
+            else None
+        ),
+        valid_mask=mask_tensor,
+    )
+
+
+def test_alignment_metrics_distinguish_order_set_mass_and_fragility():
+    behavior = _metric_trace(
+        [[0, 1], [2, 3]],
+        [[0.7, 0.3], [0.6, 0.4]],
+        [0.01, 0.20],
+        policy_version=4,
+    )
+    current = _metric_trace(
+        [[1, 0], [2, 4]],
+        [[0.3, 0.7], [0.5, 0.5]],
+        [0.02, 0.30],
+        policy_version=5,
+    )
+
+    metrics = compare_route_traces(behavior, current, fragile_margin_threshold=0.05)
+
+    assert metrics.behavior_policy_version == 4
+    assert metrics.current_policy_version == 5
+    assert metrics.valid_token_count == 2
+    assert metrics.compared_token_layer_count == 2
+    assert metrics.ordered_topk_match_fraction == 0.0
+    assert metrics.unordered_topk_overlap_fraction == pytest.approx(0.75)
+    assert metrics.route_set_flip_fraction == pytest.approx(0.25)
+    assert metrics.selected_weight_l1_mean == pytest.approx(0.5, abs=1e-3)
+    assert metrics.behavior_margin_mean == pytest.approx(0.105, abs=1e-3)
+    assert metrics.behavior_fragile_fraction == pytest.approx(0.5)
+    assert metrics.to_dict()["fragile_margin_threshold"] == 0.05
+
+
+def test_ids_only_metrics_do_not_fabricate_gate_or_margin_values():
+    behavior = _metric_trace([[0, 1], [2, 3]], policy_version=0)
+    current = _metric_trace([[0, 1], [2, 4]], policy_version=1)
+
+    metrics = compare_route_traces(behavior, current)
+
+    assert metrics.ordered_topk_match_fraction == 0.5
+    assert metrics.unordered_topk_overlap_fraction == 0.75
+    assert metrics.selected_weight_l1_mean is None
+    assert metrics.behavior_margin_mean is None
+    assert metrics.behavior_fragile_fraction is None
+    with pytest.raises(RouteTraceValidationError, match="require behavior topk_margin"):
+        compare_route_traces(behavior, current, fragile_margin_threshold=0.1)
+
+
+def test_metrics_require_exact_schema_layout_mask_and_device_semantics():
+    behavior = _metric_trace([[0, 1], [2, 3]], valid_mask=[True, False])
+    current = _metric_trace([[0, 1], [2, 3]], policy_version=1, valid_mask=[True, True])
+    with pytest.raises(RouteTraceValidationError, match="validity masks"):
+        compare_route_traces(behavior, current)
+
+    schema = replace(current.router_schema, backend="different")
+    identity = replace(current.identity, router_schema_hash=schema.fingerprint)
+    mismatched_schema = replace(current, router_schema=schema, identity=identity)
+    with pytest.raises(RouteTraceValidationError, match="router schema"):
+        compare_route_traces(behavior, mismatched_schema)
+
+
+def test_metrics_reject_empty_valid_population_and_bad_threshold():
+    behavior = _metric_trace([[0, 0], [0, 0]], valid_mask=[False, False])
+    current = _metric_trace(
+        [[0, 0], [0, 0]], policy_version=1, valid_mask=[False, False]
+    )
+    with pytest.raises(RouteTraceValidationError, match="at least one valid"):
+        compare_route_traces(behavior, current)
+    valid = _metric_trace([[0, 1], [2, 3]])
+    with pytest.raises(RouteTraceValidationError, match="finite non-negative"):
+        compare_route_traces(valid, valid, fragile_margin_threshold=float("nan"))
+
+
+def test_bfloat16_near_tie_margin_uses_explicit_fp32_reference():
+    scores = torch.tensor(
+        [[1.0, 0.984375, 0.5], [1.0, 1.0, 0.25]], dtype=torch.bfloat16
+    )
+
+    margin = compute_topk_margin(scores, top_k=1)
+
+    torch.testing.assert_close(margin, compute_topk_margin(scores.float(), top_k=1))
+    assert margin.dtype is torch.float32
+    assert margin.tolist() == pytest.approx([0.015625, 0.0])
+
+
+@pytest.mark.parametrize("top_k", [0, 3, True])
+def test_margin_rejects_invalid_top_k(top_k):
+    with pytest.raises(RouteTraceValidationError, match="top_k|top-k"):
+        compute_topk_margin(torch.ones(2, 3), top_k)
+
+
+def test_margin_rejects_nonfinite_scores():
+    scores = torch.tensor([[1.0, float("nan"), 0.0]])
+    with pytest.raises(RouteTraceValidationError, match="finite"):
+        compute_topk_margin(scores, 1)

--- a/tests/moe/test_route_trace.py
+++ b/tests/moe/test_route_trace.py
@@ -1,0 +1,453 @@
+"""Tests for the version-zero semantic MoE route trace contract."""
+
+import json
+from dataclasses import replace
+
+import pytest
+import safetensors.torch as safetensors
+import torch
+
+from astrai.moe import (
+    ROUTE_TRACE_SCHEMA_VERSION,
+    PaddingLayout,
+    RouteIdentityV0,
+    RouterSchemaV0,
+    RouteTokenLayoutV0,
+    RouteTraceCodecV0,
+    RouteTraceLevel,
+    RouteTraceV0,
+    RouteTraceValidationError,
+    SelectedWeightSemantics,
+    TokenSpanKind,
+    canonical_json_digest,
+    pack_route_ids,
+    recommended_route_id_dtype,
+    require_compatible_route_trace,
+    validate_route_trace,
+)
+
+_MANIFEST_TENSOR = "__route_trace_manifest_v0__"
+
+
+def _schema(
+    *,
+    num_experts=8,
+    padding_layout=PaddingLayout.RIGHT,
+    backend="astrai-torch",
+):
+    return RouterSchemaV0(
+        num_moe_layers=2,
+        num_experts=num_experts,
+        top_k=2,
+        expert_parallel_world_size=1,
+        score_function="softmax-fp32-before-topk",
+        score_dtype="float32",
+        expert_id_ordering="score-descending-stable-index",
+        selected_weight_semantics=SelectedWeightSemantics.SELECTED_RENORMALIZED,
+        token_ordering="single-sequence-token-major",
+        padding_layout=padding_layout,
+        backend=backend,
+        kernel_semantics_version="torch-topk-v1",
+        parallel_layout_hash=canonical_json_digest(
+            {"expert_parallel_world_size": 1, "placement": "all-experts-local"}
+        ),
+    )
+
+
+def _trace(*, num_experts=8, level=RouteTraceLevel.IDS_WEIGHTS_MARGIN):
+    schema = _schema(num_experts=num_experts)
+    identity = RouteIdentityV0(
+        policy_version=7,
+        model_revision="model-revision-7",
+        router_state_version=11,
+        checkpoint_revision="checkpoint-7",
+        router_schema_hash=schema.fingerprint,
+        load_controller_version=3,
+    )
+    token_layout = RouteTokenLayoutV0(
+        sample_id="sample-17",
+        sequence_token_count=6,
+        prompt_token_count=2,
+        token_offset=2,
+        token_count=4,
+        span_kind=TokenSpanKind.RESPONSE,
+    )
+    topk_ids = pack_route_ids(
+        torch.tensor(
+            [
+                [[0, 1], [2, 3]],
+                [[1, 2], [3, 4]],
+                [[2, 3], [4, 5]],
+                [[0, 0], [0, 0]],
+            ]
+        ),
+        num_experts,
+    )
+    valid_mask = torch.tensor([True, True, True, False])
+    if level is RouteTraceLevel.IDS:
+        return RouteTraceV0(
+            identity=identity,
+            router_schema=schema,
+            token_layout=token_layout,
+            level=level,
+            topk_ids=topk_ids,
+            valid_mask=valid_mask,
+        )
+    selected_weights = torch.tensor(
+        [
+            [[0.75, 0.25], [0.60, 0.40]],
+            [[0.55, 0.45], [0.80, 0.20]],
+            [[0.50, 0.50], [0.65, 0.35]],
+            [[0.00, 0.00], [0.00, 0.00]],
+        ],
+        dtype=torch.float16,
+    )
+    topk_margin = torch.tensor(
+        [[0.20, 0.10], [0.01, 0.30], [0.05, 0.25], [0.00, 0.00]],
+        dtype=torch.float16,
+    )
+    return RouteTraceV0(
+        identity=identity,
+        router_schema=schema,
+        token_layout=token_layout,
+        level=level,
+        topk_ids=topk_ids,
+        selected_weights=selected_weights,
+        topk_margin=topk_margin,
+        valid_mask=valid_mask,
+    )
+
+
+def _rewrite_manifest(blob, mutate):
+    tensors = safetensors.load(blob)
+    manifest = json.loads(bytes(tensors[_MANIFEST_TENSOR].tolist()))
+    mutate(manifest, tensors)
+    manifest_bytes = json.dumps(
+        manifest, sort_keys=True, separators=(",", ":")
+    ).encode()
+    tensors[_MANIFEST_TENSOR] = torch.tensor(list(manifest_bytes), dtype=torch.uint8)
+    return safetensors.save(tensors)
+
+
+@pytest.mark.parametrize(
+    ("num_experts", "expected_dtype"),
+    [
+        (8, torch.uint8),
+        (256, torch.uint8),
+        (257, torch.uint16),
+        (65536, torch.uint16),
+        (65537, torch.uint32),
+    ],
+)
+def test_route_id_dtype_is_narrow_and_codec_round_trips(num_experts, expected_dtype):
+    trace = _trace(num_experts=num_experts)
+
+    blob = RouteTraceCodecV0.dumps(trace)
+    restored = RouteTraceCodecV0.loads(blob)
+
+    assert restored.topk_ids.dtype is expected_dtype
+    assert restored.identity == trace.identity
+    assert restored.router_schema == trace.router_schema
+    assert restored.token_layout == trace.token_layout
+    assert restored.level is RouteTraceLevel.IDS_WEIGHTS_MARGIN
+    assert restored.valid_token_count == 3
+    assert (
+        restored.payload_nbytes
+        == 52 + 16 * torch.empty((), dtype=expected_dtype).element_size()
+    )
+    assert torch.equal(restored.topk_ids, trace.topk_ids.cpu())
+    assert torch.equal(restored.selected_weights, trace.selected_weights.cpu())
+    assert torch.equal(restored.topk_margin, trace.topk_margin.cpu())
+    assert torch.equal(restored.valid_mask, trace.valid_mask.cpu())
+    assert RouteTraceCodecV0.dumps(restored) == blob
+    assert restored.artifact_digest == trace.artifact_digest
+
+
+def test_ids_only_level_round_trips_without_fabricating_optional_metrics():
+    trace = _trace(level=RouteTraceLevel.IDS)
+
+    restored = RouteTraceCodecV0.loads(RouteTraceCodecV0.dumps(trace))
+
+    assert restored.selected_weights is None
+    assert restored.topk_margin is None
+    assert restored.valid_mask is not None
+
+
+@pytest.mark.parametrize("num_experts", [0, -1, 2**32 + 1, True])
+def test_recommended_dtype_rejects_invalid_expert_counts(num_experts):
+    with pytest.raises(RouteTraceValidationError, match="num_experts"):
+        recommended_route_id_dtype(num_experts)
+
+
+def test_pack_route_ids_rejects_negative_and_out_of_range_values():
+    with pytest.raises(RouteTraceValidationError, match="outside the declared range"):
+        pack_route_ids(torch.tensor([[[-1, 0]]]), 8)
+    with pytest.raises(RouteTraceValidationError, match="outside the declared range"):
+        pack_route_ids(torch.tensor([[[0, 8]]]), 8)
+    with pytest.raises(RouteTraceValidationError, match="integer dtype"):
+        pack_route_ids(torch.tensor([[[0.0, 1.0]]]), 8)
+
+
+@pytest.mark.parametrize("policy_version", [-1, True, 1.5])
+def test_identity_rejects_invalid_policy_version(policy_version):
+    schema = _schema()
+    with pytest.raises(RouteTraceValidationError, match="policy_version"):
+        RouteIdentityV0(
+            policy_version=policy_version,
+            model_revision="model",
+            router_state_version=0,
+            checkpoint_revision="checkpoint",
+            router_schema_hash=schema.fingerprint,
+        )
+
+
+def test_schema_hash_mismatch_fails_closed():
+    trace = _trace()
+    bad_identity = replace(trace.identity, router_schema_hash="0" * 64)
+
+    with pytest.raises(RouteTraceValidationError, match="router_schema_hash"):
+        replace(trace, identity=bad_identity)
+
+
+@pytest.mark.parametrize(
+    ("layout", "message"),
+    [
+        (
+            RouteTokenLayoutV0(
+                sample_id="sample",
+                sequence_token_count=8,
+                prompt_token_count=3,
+                token_offset=3,
+                token_count=2,
+                span_kind=TokenSpanKind.RESPONSE,
+            ),
+            None,
+        ),
+    ],
+)
+def test_valid_token_layout(layout, message):
+    assert layout.token_offset == 3
+    assert message is None
+
+
+def test_invalid_token_boundaries_fail_closed():
+    with pytest.raises(RouteTraceValidationError, match="exceeds"):
+        RouteTokenLayoutV0(
+            sample_id="sample",
+            sequence_token_count=4,
+            prompt_token_count=2,
+            token_offset=3,
+            token_count=2,
+            span_kind=TokenSpanKind.CONTIGUOUS,
+        )
+    with pytest.raises(RouteTraceValidationError, match="inside the prompt"):
+        RouteTokenLayoutV0(
+            sample_id="sample",
+            sequence_token_count=4,
+            prompt_token_count=2,
+            token_offset=1,
+            token_count=2,
+            span_kind=TokenSpanKind.RESPONSE,
+        )
+    with pytest.raises(RouteTraceValidationError, match="exactly cover"):
+        RouteTokenLayoutV0(
+            sample_id="sample",
+            sequence_token_count=4,
+            prompt_token_count=2,
+            token_offset=0,
+            token_count=1,
+            span_kind=TokenSpanKind.PROMPT,
+        )
+
+
+def test_tensor_shape_dtype_range_and_uniqueness_are_strict():
+    trace = _trace()
+    with pytest.raises(RouteTraceValidationError, match="shape"):
+        replace(trace, topk_ids=trace.topk_ids[:3])
+    with pytest.raises(RouteTraceValidationError, match="compact dtype"):
+        replace(trace, topk_ids=trace.topk_ids.to(torch.int64))
+    out_of_range = trace.topk_ids.clone()
+    out_of_range[0, 0, 0] = trace.router_schema.num_experts
+    with pytest.raises(RouteTraceValidationError, match="outside the declared range"):
+        replace(trace, topk_ids=out_of_range)
+    duplicate = trace.topk_ids.clone()
+    duplicate[0, 0] = duplicate[0, 0, 0]
+    with pytest.raises(RouteTraceValidationError, match="duplicate experts"):
+        replace(trace, topk_ids=duplicate)
+    with pytest.raises(RouteTraceValidationError, match="materialized strided"):
+        replace(
+            trace,
+            topk_ids=torch.empty(
+                trace.topk_ids.shape, dtype=trace.topk_ids.dtype, device="meta"
+            ),
+        )
+
+
+def test_padding_mask_and_invalid_rows_must_be_canonical():
+    trace = _trace()
+    with pytest.raises(RouteTraceValidationError, match="right padding"):
+        replace(trace, valid_mask=torch.tensor([True, False, True, False]))
+    invalid_ids = trace.topk_ids.clone()
+    invalid_ids[-1, 0, 0] = 1
+    with pytest.raises(RouteTraceValidationError, match="canonical zero expert"):
+        replace(trace, topk_ids=invalid_ids)
+    invalid_weights = trace.selected_weights.clone()
+    invalid_weights[-1, 0, 0] = 1
+    with pytest.raises(RouteTraceValidationError, match="canonical zero weights"):
+        replace(trace, selected_weights=invalid_weights)
+
+
+def test_explicit_padding_requires_a_mask():
+    trace = _trace()
+    schema = replace(trace.router_schema, padding_layout=PaddingLayout.EXPLICIT_MASK)
+    identity = replace(trace.identity, router_schema_hash=schema.fingerprint)
+    with pytest.raises(RouteTraceValidationError, match="requires valid_mask"):
+        replace(trace, router_schema=schema, identity=identity, valid_mask=None)
+
+
+def test_weight_and_margin_contract_rejects_invalid_values():
+    trace = _trace()
+    wrong_sum = trace.selected_weights.clone()
+    wrong_sum[0, 0] = torch.tensor([0.2, 0.2])
+    with pytest.raises(RouteTraceValidationError, match="sum to one"):
+        replace(trace, selected_weights=wrong_sum)
+    nan_margin = trace.topk_margin.clone()
+    nan_margin[0, 0] = float("nan")
+    with pytest.raises(RouteTraceValidationError, match="finite"):
+        replace(trace, topk_margin=nan_margin)
+    with pytest.raises(RouteTraceValidationError, match="cannot carry"):
+        replace(trace, level=RouteTraceLevel.IDS)
+    with pytest.raises(RouteTraceValidationError, match="requires weights"):
+        replace(trace, selected_weights=None, topk_margin=None)
+    with pytest.raises(RouteTraceValidationError, match="torch.Tensor"):
+        replace(trace, selected_weights="not-a-tensor")
+    negative_zero = trace.topk_margin.clone()
+    negative_zero[0, 0] = -0.0
+    with pytest.raises(RouteTraceValidationError, match="canonical positive zero"):
+        replace(trace, topk_margin=negative_zero)
+
+
+def test_full_softmax_selected_mass_allows_subunit_mass_only():
+    trace = _trace()
+    schema = replace(
+        trace.router_schema,
+        selected_weight_semantics=SelectedWeightSemantics.FULL_SOFTMAX_SELECTED,
+    )
+    identity = replace(trace.identity, router_schema_hash=schema.fingerprint)
+    weights = trace.selected_weights * 0.5
+    valid = replace(
+        trace, router_schema=schema, identity=identity, selected_weights=weights
+    )
+    validate_route_trace(valid)
+    too_large = weights.clone()
+    too_large[0, 0] = torch.tensor([0.8, 0.4])
+    with pytest.raises(RouteTraceValidationError, match="selected mass"):
+        replace(valid, selected_weights=too_large)
+
+
+def test_exact_consumer_compatibility_rejects_every_identity_or_semantic_mismatch():
+    trace = _trace()
+    require_compatible_route_trace(
+        trace,
+        expected_identity=trace.identity,
+        expected_router_schema=trace.router_schema,
+        expected_token_layout=trace.token_layout,
+        minimum_level=RouteTraceLevel.IDS_WEIGHTS_MARGIN,
+    )
+    with pytest.raises(RouteTraceValidationError, match="route identity"):
+        require_compatible_route_trace(
+            trace,
+            expected_identity=replace(trace.identity, policy_version=8),
+            expected_router_schema=trace.router_schema,
+            expected_token_layout=trace.token_layout,
+        )
+    with pytest.raises(RouteTraceValidationError, match="router schema"):
+        require_compatible_route_trace(
+            trace,
+            expected_identity=trace.identity,
+            expected_router_schema=replace(
+                trace.router_schema, backend="other-backend"
+            ),
+            expected_token_layout=trace.token_layout,
+        )
+    with pytest.raises(RouteTraceValidationError, match="token layout"):
+        require_compatible_route_trace(
+            trace,
+            expected_identity=trace.identity,
+            expected_router_schema=trace.router_schema,
+            expected_token_layout=replace(trace.token_layout, sample_id="other-sample"),
+        )
+    ids_only = _trace(level=RouteTraceLevel.IDS)
+    with pytest.raises(RouteTraceValidationError, match="does not satisfy"):
+        require_compatible_route_trace(
+            ids_only,
+            expected_identity=ids_only.identity,
+            expected_router_schema=ids_only.router_schema,
+            expected_token_layout=ids_only.token_layout,
+            minimum_level=RouteTraceLevel.IDS_WEIGHTS_MARGIN,
+        )
+
+
+def test_codec_rejects_unknown_schema_fields_versions_and_tensors():
+    blob = RouteTraceCodecV0.dumps(_trace())
+    unknown_field = _rewrite_manifest(
+        blob, lambda manifest, _: manifest.update({"future": 1})
+    )
+    with pytest.raises(RouteTraceValidationError, match="manifest keys"):
+        RouteTraceCodecV0.loads(unknown_field)
+    future_version = _rewrite_manifest(
+        blob,
+        lambda manifest, _: manifest.update(
+            {"route_trace_schema_version": ROUTE_TRACE_SCHEMA_VERSION + 1}
+        ),
+    )
+    with pytest.raises(
+        RouteTraceValidationError, match="unsupported route trace schema version"
+    ):
+        RouteTraceCodecV0.loads(future_version)
+    boolean_version = _rewrite_manifest(
+        blob,
+        lambda manifest, _: manifest.update({"route_trace_schema_version": False}),
+    )
+    with pytest.raises(
+        RouteTraceValidationError, match="unsupported route trace schema version"
+    ):
+        RouteTraceCodecV0.loads(boolean_version)
+    wrong_byte_order = _rewrite_manifest(
+        blob, lambda manifest, _: manifest.update({"byte_order": "big"})
+    )
+    with pytest.raises(
+        RouteTraceValidationError, match="unsupported route trace byte order"
+    ):
+        RouteTraceCodecV0.loads(wrong_byte_order)
+
+    def add_tensor(_, tensors):
+        tensors["tensor.future"] = torch.zeros(1, dtype=torch.uint8)
+
+    extra_tensor = _rewrite_manifest(blob, add_tensor)
+    with pytest.raises(RouteTraceValidationError, match="tensor names"):
+        RouteTraceCodecV0.loads(extra_tensor)
+
+
+def test_codec_rejects_corruption_and_size_budget_violation():
+    blob = RouteTraceCodecV0.dumps(_trace())
+
+    def corrupt_ids(_, tensors):
+        tensors["tensor.topk_ids"][0] ^= 1
+
+    corrupted = _rewrite_manifest(blob, corrupt_ids)
+    with pytest.raises(RouteTraceValidationError, match="checksum mismatch"):
+        RouteTraceCodecV0.loads(corrupted)
+    with pytest.raises(RouteTraceValidationError, match="exceeds the size limit"):
+        RouteTraceCodecV0.loads(blob, max_serialized_bytes=len(blob) - 1)
+    with pytest.raises(RouteTraceValidationError, match="safetensors"):
+        RouteTraceCodecV0.loads(b"not-a-safetensors-file")
+
+
+def test_manifest_subobjects_are_strictly_versioned():
+    blob = RouteTraceCodecV0.dumps(_trace())
+    unknown_identity = _rewrite_manifest(
+        blob, lambda manifest, _: manifest["identity"].update({"future": 1})
+    )
+    with pytest.raises(RouteTraceValidationError, match="identity keys"):
+        RouteTraceCodecV0.loads(unknown_identity)

--- a/tests/moe/test_route_trace_benchmark.py
+++ b/tests/moe/test_route_trace_benchmark.py
@@ -1,0 +1,59 @@
+"""Tests for deterministic RouteTraceV0 codec benchmark setup and reporting."""
+
+import pytest
+import torch
+
+from astrai.moe import RouteTraceLevel
+from scripts.benchmark_route_trace_codec import build_trace, run_benchmark
+
+
+@pytest.mark.parametrize("level", list(RouteTraceLevel))
+def test_codec_benchmark_reports_scope_bytes_and_latency(level):
+    report = run_benchmark(
+        tokens=4,
+        layers=2,
+        top_k=2,
+        num_experts=8,
+        level=level,
+        device=torch.device("cpu"),
+        warmups=0,
+        repeats=2,
+    )
+
+    assert report["schema_version"] == 1
+    assert report["benchmark"] == "astrai-route-trace-codec-v0"
+    assert report["parameters"]["level"] == level.value
+    assert report["bytes"]["wire"] > report["bytes"]["logical_payload"]
+    assert report["bytes"]["wire_per_token"] > 0
+    assert report["latency_us"]["serialize_median"] > 0
+    assert report["latency_us"]["deserialize_median"] > 0
+    assert len(report["artifact_digest"]) == 64
+
+
+def test_codec_benchmark_builds_compact_ids_for_large_expert_count():
+    trace = build_trace(
+        tokens=2,
+        layers=1,
+        top_k=2,
+        num_experts=257,
+        level=RouteTraceLevel.IDS,
+        device=torch.device("cpu"),
+    )
+
+    assert trace.topk_ids.dtype is torch.uint16
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"tokens": 0, "layers": 1, "top_k": 1, "num_experts": 2},
+        {"tokens": 1, "layers": 1, "top_k": 3, "num_experts": 2},
+    ],
+)
+def test_codec_benchmark_rejects_invalid_geometry(kwargs):
+    with pytest.raises(ValueError):
+        build_trace(
+            **kwargs,
+            level=RouteTraceLevel.IDS,
+            device=torch.device("cpu"),
+        )

--- a/tests/trainer/test_route_recompute_checkpoint.py
+++ b/tests/trainer/test_route_recompute_checkpoint.py
@@ -23,9 +23,9 @@ def _make_moe(device):
         n_layers=2,
     )
     model.apply(
-        lambda module: module.reset_parameters()
-        if hasattr(module, "reset_parameters")
-        else None
+        lambda module: (
+            module.reset_parameters() if hasattr(module, "reset_parameters") else None
+        )
     )
     return model.to(device)
 

--- a/tests/trainer/test_route_recompute_checkpoint.py
+++ b/tests/trainer/test_route_recompute_checkpoint.py
@@ -1,0 +1,189 @@
+"""Integration tests for opt-in checkpoint route validation."""
+
+import copy
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from astrai.model.components.mlp import DeepSeekMoE
+from astrai.moe import RecomputeRouteMismatchError
+from astrai.trainer.train_callback import GradientCheckpointingCallback
+from astrai.trainer.trainer import Trainer
+
+
+def _make_moe(device):
+    model = DeepSeekMoE(
+        dim=8,
+        dim_ffn=16,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        n_activated_experts=2,
+        n_layers=2,
+    )
+    model.apply(
+        lambda module: module.reset_parameters()
+        if hasattr(module, "reset_parameters")
+        else None
+    )
+    return model.to(device)
+
+
+def _loss(output):
+    return output["hidden_states"].square().mean() + 0.01 * output["aux_loss"]
+
+
+def test_checkpoint_validator_preserves_output_and_gradient_parity(device):
+    torch.manual_seed(7)
+    reference = _make_moe(device).train()
+    checkpointed = copy.deepcopy(reference).train()
+    reference_input = torch.randn(2, 3, 8, device=device, requires_grad=True)
+    checkpointed_input = reference_input.detach().clone().requires_grad_(True)
+
+    reference_output = reference(reference_input)
+    _loss(reference_output).backward()
+
+    callback = GradientCheckpointingCallback(
+        modules=[DeepSeekMoE], route_validation="record"
+    )
+    callback._enable(checkpointed)
+    checkpointed_output = checkpointed(checkpointed_input)
+    _loss(checkpointed_output).backward()
+
+    torch.testing.assert_close(
+        reference_output["hidden_states"], checkpointed_output["hidden_states"]
+    )
+    torch.testing.assert_close(reference_input.grad, checkpointed_input.grad)
+    for (reference_name, reference_parameter), (
+        checkpointed_name,
+        checkpointed_parameter,
+    ) in zip(reference.named_parameters(), checkpointed.named_parameters()):
+        assert reference_name == checkpointed_name
+        torch.testing.assert_close(
+            reference_parameter.grad, checkpointed_parameter.grad
+        )
+
+    context = SimpleNamespace(metrics={}, rank=0)
+    callback.on_batch_end(context)
+    summary = callback.last_route_summary
+    assert summary.forward_pair_count == 1
+    assert summary.compared_pair_count == 1
+    assert summary.exact_pair_count == 1
+    assert summary.has_failure is False
+    assert context.metrics["forward_recompute_route_match"] == 1.0
+    callback._disable(checkpointed)
+
+
+class _ChangingRouteModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.eye(4))
+        self.calls = 0
+
+    def forward(self, value):
+        hidden = torch.sin(value @ self.weight)
+        topk_indices = torch.tensor(
+            [[0, 1], [2, 3]], dtype=torch.int64, device=value.device
+        )
+        if self.calls:
+            topk_indices[0, 0] = 3
+        self.calls += 1
+        return {
+            "hidden_states": hidden,
+            "aux_loss": None,
+            "router_stats": {"topk_indices": topk_indices},
+        }
+
+
+def test_error_mode_raises_on_all_checks_after_backward(device):
+    module = _ChangingRouteModule().to(device)
+    callback = GradientCheckpointingCallback(
+        modules=[_ChangingRouteModule], route_validation="error"
+    )
+    callback._enable(module)
+    value = torch.randn(2, 4, device=device, requires_grad=True)
+    module(value)["hidden_states"].sum().backward()
+
+    context = SimpleNamespace(metrics={}, rank=0)
+    with pytest.raises(RecomputeRouteMismatchError, match="mismatch_pairs=1"):
+        callback.on_batch_end(context)
+    assert callback.last_route_summary.mismatch_pair_count == 1
+    assert context.metrics["route_recompute_mismatch_tokens"] == 1.0
+    callback._disable(module)
+
+
+def test_record_mode_exposes_mismatch_without_changing_backward(device):
+    module = _ChangingRouteModule().to(device)
+    callback = GradientCheckpointingCallback(
+        modules=[_ChangingRouteModule], route_validation="record"
+    )
+    callback._enable(module)
+    value = torch.randn(2, 4, device=device, requires_grad=True)
+    module(value)["hidden_states"].sum().backward()
+
+    context = SimpleNamespace(metrics={}, rank=0)
+    callback.on_batch_end(context)
+    assert callback.last_route_summary.has_failure is True
+    assert context.metrics["forward_recompute_route_match"] == 0.0
+    assert value.grad is not None
+    callback._disable(module)
+
+
+def test_error_mode_rejects_a_forward_route_without_recomputation():
+    callback = GradientCheckpointingCallback(route_validation="error")
+    callback.route_diagnostics.record_forward_pair()
+    context = SimpleNamespace(metrics={}, rank=0)
+
+    with pytest.raises(RecomputeRouteMismatchError, match="unrecomputed_pairs=1"):
+        callback.on_batch_end(context)
+    assert context.metrics["route_recompute_unrecomputed_pairs"] == 1.0
+
+
+def test_callback_rejects_unknown_route_validation_mode():
+    with pytest.raises(ValueError, match="route_validation must be one of"):
+        GradientCheckpointingCallback(route_validation="unknown")
+
+
+def test_train_config_wires_route_validation_and_rejects_unsafe_combinations(
+    train_config_factory,
+    test_model,
+    random_dataset,
+    temp_dir,
+    device,
+):
+    common = {
+        "model_fn": lambda: test_model["model"],
+        "dataset": random_dataset,
+        "test_dir": temp_dir,
+        "device": device,
+    }
+    config = train_config_factory(
+        **common,
+        gradient_checkpointing_modules=[DeepSeekMoE],
+        gradient_checkpointing_route_validation="record",
+    )
+    callback = next(
+        item
+        for item in Trainer(config).callbacks
+        if isinstance(item, GradientCheckpointingCallback)
+    )
+    assert callback.route_validation == "record"
+
+    with pytest.raises(ValueError, match="must be one of"):
+        train_config_factory(
+            **common,
+            gradient_checkpointing_route_validation="unknown",
+        )
+    with pytest.raises(ValueError, match="requires gradient_checkpointing_modules"):
+        train_config_factory(
+            **common,
+            gradient_checkpointing_route_validation="record",
+        )
+    with pytest.raises(ValueError, match="not supported with torch.compile"):
+        train_config_factory(
+            **common,
+            gradient_checkpointing_modules=[DeepSeekMoE],
+            gradient_checkpointing_route_validation="record",
+            compile_mode="default",
+        )


### PR DESCRIPTION
## Summary

Depends on #64 (RouteTraceV0).

### Exact-head confirmation (2026-09-05)

`python -m pytest -p no:cacheprovider -q tests/` at
`5ec2af4c8446a5acb118c2a3c12c4d982a182656`: **758 passed, 57 skipped in 60.95s**, container exit 0.
This final run retained its log independently of SSH connectivity. It used
the CPU-only environment described below; GPU tests remain skipped.

Compare ordered top-k MoE routes between forward and activation-checkpoint
recomputation. Pair observations per checkpoint invocation, report bounded
mismatch/completeness metrics, and synchronize the decision across initialized
ranks before optimizer updates. Modes are opt-in `record` / `error`; `off`
preserves the existing checkpoint path.

Uses checkpoint forward/recompute contexts, not a global call counter. Opt-in
modes disable early stopping for a complete second observation, and reject
torch.compile. No router modification, route replay, admission/objective change
or training-speed optimization is included.

## Revision and dependency

- Base: main `e1e533c88e74efab4f379d6ccbc830c2b3e698e2`.
- Head/review increment: `5ec2af4c8446a5acb118c2a3c12c4d982a182656`.
- Depends on RouteTraceV0 `89beef87e9f56ce921c3dd3bf0fee66041599071`
  (`codex/draft-moe-route-trace-v0`); main-based diff includes that dependency.
- Existing #57 concerns router consistency, not activation-checkpoint route
  observation and cross-rank pre-optimizer validation; this is not a duplicate.

## Validation

- `python -m pytest -p no:cacheprovider -q tests/moe tests/trainer/test_route_recompute_checkpoint.py`: 64 passed at `2306f0946d43179e54c374a85d6dfcf9f60f36a1`.
- Latest main replay has an identical Python tree; changed-file Ruff 0.14.7
  import/format and `git diff --check` passed.
- Original pre-rebase full suite: 748 passed, 50 skipped; original broader
  targeted suite: 69 passed, including real CPU Gloo groups at 2 and 4 ranks.
- Fresh exact-head full-suite confirmation is recorded below when available.
  Initial collection lacked httpx2; a retry's SSH connection expired before a
  final result. Neither is claimed as a successful full-suite run.

CPU image `astrai-test:cu128`, Python 3.12.3, torch 2.11.0+cu128, pytest 8.3.5.
No GPUs exposed; httpx2 2.12.0 added only to the disposable test container.

## Historical benchmark (pre-rebase)

Checkpoint-only -> record-mode median: CPU 18.456 -> 19.040 ms (+3.163%);
one L20 12.626 -> 13.362 ms (+5.823%). Exact route hashes, outputs and gradients
matched. This measures one module's forward/backward overhead, not distributed
training, optimizer work, replay or end-to-end throughput.

## Review status

AI assistance was used. Keep Draft for human line-by-line review, dependency
review and CI. No fresh GPU result or training-speed improvement is claimed.
