### PR TITLE
fix: use launch world size for CLI scheduler steps

### DIFF
--- a/astrai/parallel/setup.py
+++ b/astrai/parallel/setup.py
@@ -256,6 +256,23 @@ def _is_external_launcher() -> bool:
     return False
 
 
+def resolve_launch_world_size(nprocs: int) -> int:
+    if not _is_external_launcher():
+        return nprocs
+    raw_world_size = os.environ.get("WORLD_SIZE")
+    try:
+        world_size = int(raw_world_size)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "WORLD_SIZE must be a positive integer for an external launcher"
+        ) from exc
+    if world_size <= 0:
+        raise ValueError(
+            "WORLD_SIZE must be a positive integer for an external launcher"
+        )
+    return world_size
+
+
 def spawn_parallel_fn(
     func: Callable,
     world_size: int,

--- a/docs/guides/distributed.md
+++ b/docs/guides/distributed.md
@@ -140,7 +140,11 @@ torchrun --nproc_per_node=4 scripts/tools/train.py \
 
 When launched via `torchrun`, the launcher creates the worker processes. AstrAI reads `RANK`, `WORLD_SIZE`, and `LOCAL_RANK` from the environment and uses `TorchrunStrategy`; `--nprocs` does not control process creation in this mode.
 
-The current training CLI still uses `--nprocs` when calculating scheduler `total_steps`. Set it to the global `WORLD_SIZE` so the step count reflects data-parallel sharding, including multi-node runs.
+For scheduler `total_steps`, the training CLI uses the global `WORLD_SIZE`
+automatically under an external launcher, including multi-node runs. Local
+launches use `--nprocs`. External `WORLD_SIZE` must be present and a positive
+integer. This selection only affects the learning-rate schedule; it does not
+rewrite `TrainConfig.nprocs` or change existing configuration validation.
 
 Raw Slurm variables such as `SLURM_PROCID`, `SLURM_NTASKS`, and `SLURM_LOCALID` are not recognized automatically. Launch through `torchrun`, or map the scheduler's variables to `RANK`, `WORLD_SIZE`, `LOCAL_RANK`, `MASTER_ADDR`, and `MASTER_PORT` before starting AstrAI. The same requirement applies to launchers that expose only OpenMPI-specific variables.
 
@@ -176,7 +180,8 @@ Checkpoints are saved by **rank-0 only**. The flow:
 The scheduler's total step count accounts for data-parallel sharding:
 
 ```
-samples_per_replica = ceil(dataset_len / nprocs)
+effective_world_size = WORLD_SIZE (external launch) or nprocs (local launch)
+samples_per_replica = ceil(dataset_len / effective_world_size)
 batches_per_replica  = ceil(samples_per_replica / batch_per_device)
 total_steps          = (batches_per_replica // grad_accum_steps) * n_epoch
 ```
@@ -250,7 +255,7 @@ python scripts/tools/train.py \
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `--nprocs` | 1 | Local process count for AstrAI's launcher; under `torchrun`, set it to global `WORLD_SIZE` for total-step calculation |
+| `--nprocs` | 1 | Local launcher process count; scheduler total steps use global `WORLD_SIZE` under external launchers instead |
 | `--parallel_mode` | `fsdp` | `none`, `ddp`, or `fsdp` |
 | `--start_method` | `spawn` | Multiprocessing start method (`spawn`, `fork`, `forkserver`) |
 | `--backend` | `nccl` | Distributed backend (`nccl`, `gloo`) |

--- a/scripts/tools/train.py
+++ b/scripts/tools/train.py
@@ -24,6 +24,7 @@ from astrai.dataset import DatasetFactory, dpo_collate_fn, grpo_collate_fn
 from astrai.model import AutoRegressiveLM, ValueModel
 from astrai.model.components.decoder_block import DecoderBlock
 from astrai.optim import OptimizerFactory
+from astrai.parallel.setup import resolve_launch_world_size
 from astrai.trainer import SchedulerFactory, Trainer
 from astrai.trainer.rollout import BaseRewardModel
 
@@ -617,8 +618,9 @@ def train(
             )
         }
 
+    effective_world_size = resolve_launch_world_size(nprocs)
     total_steps = compute_total_steps(
-        len(dataset), n_epoch, batch_per_device, nprocs, grad_accum_steps
+        len(dataset), n_epoch, batch_per_device, effective_world_size, grad_accum_steps
     )
     warmup_steps = int(warmup_ratio * total_steps)
     warmup_steps = min(warmup_steps, total_steps)

--- a/tests/config/test_cli.py
+++ b/tests/config/test_cli.py
@@ -3,7 +3,9 @@ import typing as t
 
 import click
 import pytest
+import torch
 from click.testing import CliRunner
+from torch.utils.data import TensorDataset
 
 from astrai.config import TrainConfig, merge_yaml_into_kwargs
 from astrai.config.cli import (
@@ -12,6 +14,8 @@ from astrai.config.cli import (
     apply_specs,
     option_from_spec,
 )
+from scripts.tools import train as train_cli
+from tests.helpers import make_tiny_config
 
 
 def test_merge_yaml_overrides_defaults_but_not_explicit_cli(tmp_path):
@@ -228,3 +232,82 @@ def test_help_order_follows_spec_table():
     result = CliRunner().invoke(cmd, ["--help"])
     assert result.exit_code == 0
     assert result.output.index("--first") < result.output.index("--second")
+
+
+@pytest.mark.parametrize("schedule_type", ["cosine", "sgdr", "wsd"])
+@pytest.mark.parametrize(
+    ("world_size", "cli_nprocs", "expected_steps"),
+    [(None, 1, 400), (None, 2, 200), (4, None, 100), (4, 2, 100), (1, 2, 400)],
+)
+def test_train_cli_scheduler_uses_launch_world_size(
+    monkeypatch, tmp_path, schedule_type, world_size, cli_nprocs, expected_steps
+):
+    for name in (
+        "RANK",
+        "WORLD_SIZE",
+        "LOCAL_RANK",
+        "LOCAL_WORLD_SIZE",
+        "TORCHELASTIC_RUN_ID",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    if world_size is not None:
+        monkeypatch.setenv("RANK", "0")
+        monkeypatch.setenv("WORLD_SIZE", str(world_size))
+        monkeypatch.setenv("LOCAL_RANK", "0")
+        monkeypatch.setenv("LOCAL_WORLD_SIZE", "1")
+
+    dataset = TensorDataset(torch.zeros(3200, 1))
+    monkeypatch.setattr(
+        train_cli.AutoRegressiveLMConfig, "from_file", lambda path: make_tiny_config()
+    )
+    monkeypatch.setattr(train_cli.DatasetFactory, "load", lambda **kwargs: dataset)
+    captured_configs = []
+
+    def capture_training(trainer, **kwargs):
+        captured_configs.append(trainer.train_config)
+
+    monkeypatch.setattr(train_cli.Trainer, "train", capture_training)
+    arguments = [
+        "--train_type",
+        "seq",
+        "--param_path",
+        str(tmp_path),
+        "--data_root_path",
+        str(tmp_path),
+        "--parallel_mode",
+        "ddp",
+        "--device_type",
+        "cpu",
+        "--backend",
+        "gloo",
+        "--batch_per_device",
+        "2",
+        "--grad_accum_steps",
+        "4",
+        "--n_epoch",
+        "1",
+        "--warmup_ratio",
+        "0.1",
+        "--schedule_type",
+        schedule_type,
+    ]
+    if cli_nprocs is not None:
+        arguments.extend(["--nprocs", str(cli_nprocs)])
+
+    result = CliRunner().invoke(train_cli.train_command, arguments)
+
+    assert result.exit_code == 0, (result.output, result.exception)
+    assert len(captured_configs) == 1
+    config = captured_configs[0]
+    assert config.nprocs == (1 if cli_nprocs is None else cli_nprocs)
+    optimizer = torch.optim.SGD([torch.nn.Parameter(torch.zeros(1))], lr=0.1)
+    scheduler = config.scheduler_fn(optimizer)
+    expected_warmup = expected_steps // 10
+    assert scheduler.warmup_steps == expected_warmup
+    if schedule_type == "cosine":
+        assert scheduler.lr_decay_steps == expected_steps - expected_warmup
+    elif schedule_type == "sgdr":
+        assert scheduler.cycle_length == expected_steps - expected_warmup
+    else:
+        assert scheduler.stable_steps == int((expected_steps - expected_warmup) * 0.8)
+        assert scheduler.total_steps == expected_steps

--- a/tests/parallel/test_parallel.py
+++ b/tests/parallel/test_parallel.py
@@ -1,7 +1,9 @@
+import pytest
 import torch
 import torch.distributed as dist
 
 from astrai.parallel import get_rank, only_on_rank, spawn_parallel_fn
+from astrai.parallel.setup import resolve_launch_world_size
 
 
 @only_on_rank(0)
@@ -30,3 +32,60 @@ def test_spawn_only_on_rank():
 
 def test_spawn_all_reduce():
     spawn_parallel_fn(all_reduce, world_size=2, backend="gloo")
+
+
+@pytest.fixture
+def clean_launch_environment(monkeypatch):
+    for name in ("LOCAL_WORLD_SIZE", "RANK", "WORLD_SIZE", "TORCHELASTIC_RUN_ID"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.delenv("LOCAL_RANK", raising=False)
+
+
+@pytest.mark.parametrize("nprocs", [1, 2, 4])
+def test_resolve_launch_world_size_keeps_cli_value_for_local_launch(
+    monkeypatch, clean_launch_environment, nprocs
+):
+    monkeypatch.setenv("WORLD_SIZE", "8")
+
+    assert resolve_launch_world_size(nprocs) == nprocs
+
+
+def test_resolve_launch_world_size_uses_torchrun_world_size(
+    monkeypatch, clean_launch_environment
+):
+    monkeypatch.setenv("RANK", "1")
+    monkeypatch.setenv("WORLD_SIZE", "4")
+    monkeypatch.setenv("LOCAL_RANK", "1")
+
+    assert resolve_launch_world_size(1) == 4
+
+
+@pytest.mark.parametrize("world_size", ["not-an-integer", "", "0", "-1", "1.5"])
+def test_resolve_launch_world_size_rejects_invalid_torchrun_world_size(
+    monkeypatch, clean_launch_environment, world_size
+):
+    monkeypatch.setenv("RANK", "0")
+    monkeypatch.setenv("WORLD_SIZE", world_size)
+
+    with pytest.raises(ValueError, match="WORLD_SIZE"):
+        resolve_launch_world_size(1)
+
+
+@pytest.mark.parametrize("marker", ["LOCAL_WORLD_SIZE", "TORCHELASTIC_RUN_ID"])
+def test_resolve_launch_world_size_rejects_missing_external_world_size(
+    monkeypatch, clean_launch_environment, marker
+):
+    monkeypatch.setenv(marker, "1")
+
+    with pytest.raises(ValueError, match="WORLD_SIZE"):
+        resolve_launch_world_size(2)
+
+
+@pytest.mark.parametrize("marker", ["LOCAL_WORLD_SIZE", "TORCHELASTIC_RUN_ID"])
+def test_resolve_launch_world_size_uses_existing_external_detection(
+    monkeypatch, clean_launch_environment, marker
+):
+    monkeypatch.setenv(marker, "1")
+    monkeypatch.setenv("WORLD_SIZE", "8")
+
+    assert resolve_launch_world_size(2) == 8


### PR DESCRIPTION
## Summary
- Resolve the effective world size using the existing external-launcher detection: local launches use CLI `nprocs`, while external launches require a positive integer `WORLD_SIZE`.
- Use the resolved world size only when calculating CLI scheduler total steps, so warmup and decay lengths reflect global data-parallel sharding.
- Preserve `TrainConfig.nprocs`, launcher behavior, and existing configuration validation; update the distributed training guide.

## Tests
- Add launch-world-size resolution tests and CLI-to-scheduler regression coverage for cosine, SGDR, and WSD, including mismatched CLI and environment values.
- Before CLI wiring: regression tests reproduced the bug (9 failed, 6 passed). After the fix: targeted tests passed (38 passed, 2 deselected).
- Full CPU test suite: `python -m pytest -q tests/ --tb=short` resulted in 712 passed, 50 skipped, and 2 dependency deprecation warnings. Tests requiring localhost sockets were rerun successfully outside the sandbox.
- Ruff import checks, formatting checks, and `git diff --check` passed.

## Limitations
- Validated on macOS ARM64 with Python 3.12.13 and PyTorch 2.11.0.
- No actual GPU training or multi-node torchrun execution; CLI regression tests simulate launcher environment variables and instantiate real schedulers without starting training.