### PR TITLE
feat: integrate INT8 GEMV decode acceleration

### DIFF
--- a/astrai/extension/__init__.py
+++ b/astrai/extension/__init__.py
@@ -54,6 +54,10 @@ from astrai.extension.ops import (
     attn_paged_decode,
     attn_paged_prefill,
     attn_prefill,
+    linear_forward_int8,
+    mm_int8,
+    quantize_dynamic_bf16,
+    quantize_weight_bf16,
 )
 
 __all__ = [
@@ -71,6 +75,10 @@ __all__ = [
     "attn_paged_decode",
     "attn_prefill",
     "attn_paged_prefill",
+    "quantize_dynamic_bf16",
+    "quantize_weight_bf16",
+    "mm_int8",
+    "linear_forward_int8",
     "is_available",
     "KERNEL_NAMES",
     "apply_rotary_emb",

--- a/astrai/extension/ops/__init__.py
+++ b/astrai/extension/ops/__init__.py
@@ -8,6 +8,12 @@ from astrai.extension.ops.attention import (
     attn_prefill,
 )
 from astrai.extension.ops.rotary import rotary_emb
+from astrai.extension.ops.int8 import (
+    linear_forward_int8,
+    mm_int8,
+    quantize_dynamic_bf16,
+    quantize_weight_bf16,
+)
 
 __all__ = [
     "TensorLayout",
@@ -16,4 +22,8 @@ __all__ = [
     "attn_paged_prefill",
     "attn_prefill",
     "rotary_emb",
+    "quantize_dynamic_bf16",
+    "quantize_weight_bf16",
+    "mm_int8",
+    "linear_forward_int8",
 ]

--- a/astrai/extension/ops/int8.py
+++ b/astrai/extension/ops/int8.py
@@ -1,0 +1,137 @@
+"""Stateless W8A8 inference primitives with CUDA and CPU reference paths."""
+
+import torch
+from torch.library import custom_op
+
+from astrai.extension.loader import get_module
+
+_QMAX = 127.0
+
+
+def _quantize(x: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    return torch.clamp(torch.round(x.float() / scale), -127, 127).to(torch.int8)
+
+
+@custom_op("custom::int8_quantize_dynamic", mutates_args=())
+def _quantize_dynamic(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    pass
+
+
+@_quantize_dynamic.register_fake
+def _(x):
+    return (
+        torch.empty_like(x, dtype=torch.int8),
+        torch.empty((1,), device=x.device, dtype=torch.float32),
+    )
+
+
+@_quantize_dynamic.register_kernel("cuda")
+def _(x):
+    if x.dtype != torch.bfloat16:
+        raise TypeError(f"dynamic INT8 quantization requires bf16, got {x.dtype}")
+    return get_module("int8_ops").quantize_dynamic_bf16(x)
+
+
+@_quantize_dynamic.register_kernel("cpu")
+def _(x):
+    scale = (x.abs().amax().float() / _QMAX).clamp_min(1e-12).reshape(1)
+    return _quantize(x, scale), scale
+
+
+@custom_op("custom::int8_quantize_weight", mutates_args=())
+def _quantize_weight(w: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    pass
+
+
+@_quantize_weight.register_fake
+def _(w):
+    return (
+        torch.empty_like(w, dtype=torch.int8),
+        torch.empty((w.size(0),), device=w.device, dtype=torch.float32),
+    )
+
+
+@_quantize_weight.register_kernel("cuda")
+def _(w):
+    if w.dtype != torch.bfloat16 or w.dim() != 2:
+        raise TypeError("INT8 weight quantization requires bf16 [N, K]")
+    return get_module("int8_ops").quantize_weight_bf16(w)
+
+
+@_quantize_weight.register_kernel("cpu")
+def _(w):
+    if w.dim() != 2:
+        raise ValueError("w must have shape [N, K]")
+    scale = (w.abs().amax(dim=1).float() / _QMAX).clamp_min(1e-12)
+    return _quantize(w, scale[:, None]), scale
+
+
+@custom_op("custom::int8_gemm", mutates_args=())
+def _mm_int8(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    pass
+
+
+@_mm_int8.register_fake
+def _(a, b, scale_a, scale_b, bias=None):
+    return torch.empty((a.size(0), b.size(0)), device=a.device, dtype=torch.bfloat16)
+
+
+@_mm_int8.register_kernel("cuda")
+def _(a, b, scale_a, scale_b, bias=None):
+    return get_module("int8_ops").mm_int8(a, b, scale_a, scale_b, bias)
+
+
+@_mm_int8.register_kernel("cpu")
+def _(a, b, scale_a, scale_b, bias=None):
+    out = (a.to(torch.int32) @ b.to(torch.int32).transpose(0, 1)).float()
+    out = out * scale_a.float().reshape(1, 1) * scale_b.float().reshape(1, -1)
+    if bias is not None and bias.numel():
+        out = out + bias.float().reshape(1, -1)
+    return out.to(torch.bfloat16)
+
+
+def quantize_dynamic_bf16(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize BF16 activations with one dynamic symmetric scale."""
+    if x.dtype != torch.bfloat16:
+        raise TypeError(f"x must be bfloat16, got {x.dtype}")
+    return _quantize_dynamic(x)
+
+
+def quantize_weight_bf16(w: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize BF16 [N,K] weights with one scale per output channel."""
+    if w.dtype != torch.bfloat16 or w.dim() != 2:
+        raise TypeError("w must be a bfloat16 [N, K] tensor")
+    return _quantize_weight(w)
+
+
+def mm_int8(a: torch.Tensor, b: torch.Tensor, scale_a: torch.Tensor,
+            scale_b: torch.Tensor, bias: torch.Tensor | None = None) -> torch.Tensor:
+    """Compute ``a @ b.T`` for INT8 [M,K]/[N,K] operands and return BF16."""
+    if a.dtype != torch.int8 or b.dtype != torch.int8 or a.dim() != 2 or b.dim() != 2:
+        raise TypeError("a and b must be int8 rank-2 tensors")
+    if a.size(1) != b.size(1) or scale_a.numel() != 1 or scale_b.numel() != b.size(0):
+        raise ValueError("invalid INT8 GEMM shapes or scales")
+    return _mm_int8(a, b, scale_a, scale_b, bias)
+
+
+def linear_forward_int8(x: torch.Tensor, w_q: torch.Tensor,
+                        scale_w: torch.Tensor, bias: torch.Tensor | None = None) -> torch.Tensor:
+    """BF16 linear with static INT8 [N,K] weights and dynamic activation scale."""
+    if x.dtype != torch.bfloat16 or w_q.dtype != torch.int8:
+        raise TypeError("x must be bf16 and w_q must be int8")
+    if x.size(-1) != w_q.size(1):
+        raise ValueError("x and w_q inner dimensions must match")
+    if x.is_cuda:
+        return get_module("int8_ops").linear_forward_int8(x, w_q, scale_w, bias)
+    x_q, scale_x = quantize_dynamic_bf16(x.reshape(-1, x.size(-1)))
+    out = mm_int8(x_q, w_q, scale_x, scale_w, bias)
+    return out.reshape(*x.shape[:-1], w_q.size(0))
+
+
+__all__ = ["quantize_dynamic_bf16", "quantize_weight_bf16", "mm_int8", "linear_forward_int8"]

--- a/astrai/inference/engine.py
+++ b/astrai/inference/engine.py
@@ -324,6 +324,8 @@ def build_engine(
     dtype: Optional[torch.dtype] = torch.bfloat16,
     max_batch_size: int = 16,
     max_seq_len: Optional[int] = None,
+    int8_decode: bool = False,
+    int8_attention: bool = False,
     **engine_kwargs: Any,
 ) -> InferenceEngine:
     """Composition root for inference assembly.
@@ -355,6 +357,12 @@ def build_engine(
             f"Model placed on {placement.get('device')} "
             f"with dtype {placement.get('dtype')}"
         )
+
+    if int8_decode:
+        prepared = model.set_int8_decode_enabled(
+            True, include_attention=int8_attention
+        )
+        logger.info("INT8 decode enabled: prepared %d projections", prepared)
 
     return InferenceEngine(
         model=model,

--- a/astrai/inference/network/app.py
+++ b/astrai/inference/network/app.py
@@ -162,6 +162,8 @@ def run_server(
     dtype: torch.dtype = torch.bfloat16,
     max_batch_size: int = 16,
     max_seq_len: Optional[int] = None,
+    int8_decode: bool = False,
+    int8_attention: bool = False,
 ):
     app = get_app()
     app.state.server_config = {
@@ -170,6 +172,8 @@ def run_server(
         "param_path": param_path,
         "max_batch_size": max_batch_size,
         "max_seq_len": max_seq_len,
+        "int8_decode": int8_decode,
+        "int8_attention": int8_attention,
     }
     uvicorn.run(
         app,

--- a/astrai/model/automodel.py
+++ b/astrai/model/automodel.py
@@ -128,3 +128,22 @@ class AutoModel(nn.Module):
             state_dict=self.state_dict(),
             save_directory=str(save_directory),
         )
+
+    def set_int8_decode_enabled(
+        self, enabled: bool, include_attention: bool = False
+    ) -> int:
+        """Configure supported Linear modules for decode-only W8A8 inference.
+
+        Returns the number of projections prepared with cached static INT8
+        weights. Modules without a supported shape remain ordinary BF16 Linear.
+        """
+        prepared = 0
+        for module in self.modules():
+            if module is self:
+                continue
+            configure = getattr(module, "set_int8_decode_enabled", None)
+            if configure is not None and configure(
+                enabled, include_attention=include_attention
+            ):
+                prepared += 1
+        return prepared

--- a/astrai/model/components/attention.py
+++ b/astrai/model/components/attention.py
@@ -42,10 +42,17 @@ class GQA(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_gated_attention = use_gated_attention
 
-        self.q_proj = Linear(dim, n_heads * self.head_dim)
+        self.q_proj = Linear(
+            dim, n_heads * self.head_dim, int8_decode_attention=True
+        )
         self.k_proj = Linear(dim, n_kv_heads * self.head_dim)
         self.v_proj = Linear(dim, n_kv_heads * self.head_dim)
-        self.o_proj = Linear(dim, dim, init_std=0.02 / (2 * n_layers) ** 0.5)
+        self.o_proj = Linear(
+            dim,
+            dim,
+            init_std=0.02 / (2 * n_layers) ** 0.5,
+            int8_decode_attention=True,
+        )
 
         if self.use_qk_norm:
             self.q_norm = RMSNorm(self.head_dim, norm_eps)
@@ -118,7 +125,12 @@ class MLA(nn.Module):
         self.use_qk_norm = use_qk_norm
         self.use_gated_attention = use_gated_attention
 
-        self.q_proj = Linear(dim, n_heads * self.head_dim, bias=False)
+        self.q_proj = Linear(
+            dim,
+            n_heads * self.head_dim,
+            bias=False,
+            int8_decode_attention=True,
+        )
 
         if self.use_qk_norm:
             self.q_norm = RMSNorm(self.head_dim, norm_eps)
@@ -132,7 +144,11 @@ class MLA(nn.Module):
         )
 
         self.o_proj = Linear(
-            dim, dim, bias=False, init_std=0.02 / (2 * n_layers) ** 0.5
+            dim,
+            dim,
+            bias=False,
+            init_std=0.02 / (2 * n_layers) ** 0.5,
+            int8_decode_attention=True,
         )
 
         if use_gated_attention:

--- a/astrai/model/components/linear.py
+++ b/astrai/model/components/linear.py
@@ -3,15 +3,33 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
 
+from astrai.extension.loader import is_available
+from astrai.extension.ops.int8 import linear_forward_int8, quantize_weight_bf16
+
 
 class Linear(nn.Module):
     def __init__(
-        self, in_dim: int, out_dim: int, bias: bool = False, init_std: float = 0.02
+        self,
+        in_dim: int,
+        out_dim: int,
+        bias: bool = False,
+        init_std: float = 0.02,
+        int8_decode_supported: bool = False,
+        int8_decode_attention: bool = False,
     ):
         super().__init__()
         self.weight = nn.Parameter(torch.empty((out_dim, in_dim)))
         self.bias = nn.Parameter(torch.zeros(out_dim)) if bias else None
         self.init_std = init_std
+        self._int8_decode_supported = int8_decode_supported
+        self._int8_decode_attention = int8_decode_attention
+        self._int8_attention_enabled = False
+        # Inference cache only: not serialized and never used by training.
+        self.register_buffer("_int8_weight", None, persistent=False)
+        self.register_buffer("_int8_scale", None, persistent=False)
+        self._int8_decode_enabled = False
+        self._int8_weight_version = -1
+        self._int8_weights_external = False
 
     def reset_parameters(self):
         nn.init.normal_(self.weight, mean=0.0, std=self.init_std)
@@ -20,5 +38,105 @@ class Linear(nn.Module):
             bound = 1 / (fan_in**0.5)
             nn.init.uniform_(self.bias, -bound, bound)
 
+    @property
+    def int8_decode_eligible(self) -> bool:
+        return self._int8_decode_supported or (
+            self._int8_decode_attention and self._int8_attention_enabled
+        )
+
+    def set_int8_weights(self, weight_q: Tensor, scale_w: Tensor) -> bool:
+        """Attach pre-quantized inference weights without re-quantizing them.
+
+        ``weight_q`` is stored as ``[out_features, in_features]`` INT8 and
+        ``scale_w`` contains one FP32 scale per output channel. The caller is
+        responsible for placing both tensors on the model device.
+        """
+        if weight_q.dtype != torch.int8 or weight_q.shape != self.weight.shape:
+            raise TypeError(
+                "weight_q must be int8 with the same shape as the BF16 weight"
+            )
+        if (
+            scale_w.dtype != torch.float32
+            or scale_w.device != weight_q.device
+            or scale_w.numel() != self.weight.size(0)
+        ):
+            raise TypeError("scale_w must be CUDA/CPU float32 [out_features]")
+        if weight_q.device != self.weight.device:
+            raise ValueError("weight_q must be on the same device as weight")
+        if not self.int8_decode_eligible:
+            raise ValueError("this Linear module is not eligible for INT8 decode")
+        self._int8_decode_enabled = True
+        self._int8_weight = weight_q.detach()
+        self._int8_scale = scale_w.detach().reshape(-1)
+        self._int8_weight_version = self.weight._version
+        self._int8_weights_external = True
+        return True
+
+    def set_int8_decode_enabled(
+        self, enabled: bool, include_attention: bool = False
+    ) -> bool:
+        """Enable decode-only W8A8 dispatch and eagerly cache static weights.
+
+        Returns whether this projection has a supported shape and was prepared.
+        Unsupported modules intentionally remain BF16 fallbacks.
+        """
+        self._int8_decode_enabled = enabled
+        self._int8_attention_enabled = include_attention
+        if not enabled:
+            self._int8_weight = None
+            self._int8_scale = None
+            self._int8_weight_version = -1
+            self._int8_weights_external = False
+            return False
+        return self._prepare_int8_weight()
+
+    def _prepare_int8_weight(self) -> bool:
+        if (
+            not self.int8_decode_eligible
+            or not is_available("int8_ops")
+        ):
+            return False
+        if self._int8_weights_external:
+            return (
+                self._int8_weight is not None
+                and self._int8_scale is not None
+                and self._int8_weight.dtype == torch.int8
+                and self._int8_weight.device == self.weight.device
+                and self._int8_weight.shape == self.weight.shape
+                and self._int8_scale.dtype == torch.float32
+                and self._int8_scale.numel() == self.weight.size(0)
+            )
+        if (
+            self._int8_weight is not None
+            and self._int8_scale is not None
+            and self._int8_weight_version == self.weight._version
+        ):
+            return True
+        if not self.weight.is_cuda or self.weight.dtype != torch.bfloat16:
+            return False
+        if (
+            self._int8_weight is None
+            or self._int8_scale is None
+            or self._int8_weight_version != self.weight._version
+        ):
+            with torch.no_grad():
+                self._int8_weight, self._int8_scale = quantize_weight_bf16(self.weight)
+            self._int8_weight_version = self.weight._version
+            self._int8_weights_external = False
+        return True
+
+    def _can_use_int8_decode(self, x: Tensor) -> bool:
+        return (
+            self._int8_decode_enabled
+            and not self.training
+            and not torch.is_grad_enabled()
+            and x.is_cuda
+            and x.dtype == torch.bfloat16
+            and x.numel() == self.weight.size(1)
+            and self._prepare_int8_weight()
+        )
+
     def forward(self, x: Tensor) -> Tensor:
+        if self._can_use_int8_decode(x):
+            return linear_forward_int8(x, self._int8_weight, self._int8_scale, self.bias)
         return F.linear(x, self.weight, self.bias)

--- a/astrai/model/components/mlp.py
+++ b/astrai/model/components/mlp.py
@@ -31,11 +31,22 @@ class FFNOutput(TypedDict):
 
 @FFNFactory.register("mlp")
 class MLP(nn.Module):
-    def __init__(self, dim: int, dim_ffn: int, down_init_std: float = 0.02):
+    def __init__(
+        self,
+        dim: int,
+        dim_ffn: int,
+        down_init_std: float = 0.02,
+        int8_decode_supported: bool = True,
+    ):
         super().__init__()
-        self.up = Linear(dim, dim_ffn)
-        self.gate = Linear(dim, dim_ffn)
-        self.down = Linear(dim_ffn, dim, init_std=down_init_std)
+        self.up = Linear(dim, dim_ffn, int8_decode_supported=int8_decode_supported)
+        self.gate = Linear(dim, dim_ffn, int8_decode_supported=int8_decode_supported)
+        self.down = Linear(
+            dim_ffn,
+            dim,
+            init_std=down_init_std,
+            int8_decode_supported=int8_decode_supported,
+        )
 
     def forward(self, x: Tensor) -> FFNOutput:
         gated = self.up(x) * F.silu(self.gate(x))
@@ -81,13 +92,23 @@ class DeepSeekMoE(nn.Module):
 
         self.shared_experts = nn.ModuleList(
             [
-                MLP(dim, shared_dim_ffn, down_init_std=down_init_std)
+                MLP(
+                    dim,
+                    shared_dim_ffn,
+                    down_init_std=down_init_std,
+                    int8_decode_supported=False,
+                )
                 for _ in range(n_shared_experts)
             ]
         )
         self.routed_experts = nn.ModuleList(
             [
-                MLP(dim, expert_dim_ffn, down_init_std=down_init_std)
+                MLP(
+                    dim,
+                    expert_dim_ffn,
+                    down_init_std=down_init_std,
+                    int8_decode_supported=False,
+                )
                 for _ in range(n_routed_experts)
             ]
         )

--- a/astrai/model/transformer.py
+++ b/astrai/model/transformer.py
@@ -59,7 +59,13 @@ class AutoRegressiveLM(AutoModel):
         )
 
         self.norm = RMSNorm(config.hidden_size, config.rms_norm_eps)
-        self.lm_head = Linear(config.hidden_size, config.vocab_size)
+        # The decode lm_head is a large M=1 GEMV and explicitly opts into the
+        # optional INT8 capability; other components declare their own policy.
+        self.lm_head = Linear(
+            config.hidden_size,
+            config.vocab_size,
+            int8_decode_supported=True,
+        )
 
         if self.config.tie_word_embeddings is True:
             self.lm_head.weight = self.embed_tokens.weight

--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -101,6 +101,15 @@ set(KERNEL_SRCS
     rotary_emb.cu
 )
 
+if(ASTRAI_CUDA_ARCH_MAX GREATER_EQUAL 75)
+    list(APPEND KERNEL_NAMES int8_ops)
+    list(APPEND KERNEL_SRCS int8/ops.cu)
+else()
+    message(WARNING
+        "INT8 operator disabled: max ASTRAI_CUDA_ARCH=${ASTRAI_CUDA_ARCH} "
+        "requires compute capability 75 or newer")
+endif()
+
 if(ASTRAI_CUDA_ARCH_MAX GREATER_EQUAL 89)
     list(APPEND KERNEL_NAMES quantize)
     list(APPEND KERNEL_SRCS quantize/quantize.cu)

--- a/csrc/kernels/common/device.cuh
+++ b/csrc/kernels/common/device.cuh
@@ -125,4 +125,7 @@ inline DeviceFacts device_facts() {
     return facts;
 }
 
+inline constexpr int kMinSmForInt8Major = 7;
+inline constexpr int kMinSmForInt8Minor = 5;
+
 }  // namespace astrai

--- a/csrc/kernels/common/mma.cuh
+++ b/csrc/kernels/common/mma.cuh
@@ -335,6 +335,21 @@ DEVICE_FORCEINLINE void mma_sync(float d[4], const unsigned a[4],
     MmaOp<InT, InT, typename MmaShapeFor<InT>::type>::fma(d, a, b, c);
 }
 
+// INT8 tensor-core MMA is available starting with Turing (sm_75).  Its
+// operand fragments have the same 4x/2x b32 layout as the FP8 m16n8k32
+// instruction, but the accumulator is signed int32 rather than fp32.
+DEVICE_FORCEINLINE void mma_sync_s8(int d[4], const unsigned a[4],
+                                    const unsigned b[2], const int c[4]) {
+    static_assert(ASTRAI_DEVICE_ARCH == 0 || ASTRAI_DEVICE_ARCH >= 750,
+                  "mma_sync_s8 requires sm_75 or newer");
+    asm volatile(
+        "mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 "
+        "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};"
+        : "=r"(d[0]), "=r"(d[1]), "=r"(d[2]), "=r"(d[3])
+        : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]),
+          "r"(b[1]), "r"(c[0]), "r"(c[1]), "r"(c[2]), "r"(c[3]));
+}
+
 #undef ASTRAI_DEVICE_ARCH
 
 // ---------------------------------------------------------------------------

--- a/csrc/kernels/int8/ops.cu
+++ b/csrc/kernels/int8/ops.cu
@@ -1,0 +1,876 @@
+// Stateless W8A8 inference primitives. INT8 weights use [N, K] layout and
+// one scale per output channel; activations use one dynamic scale per call.
+
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#include <cuda_bf16.h>
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include "../common/device.cuh"
+#include "../common/cp_async.cuh"
+#include "../common/mma.cuh"
+#include "../common/reduce.cuh"
+
+namespace {
+constexpr int kThreads = 256;
+constexpr float kQMax = 127.0f;
+
+__device__ __forceinline__ int8_t quantize_s8(float x, float scale) {
+    int q = __float2int_rn(x / scale);
+    q = max(-127, min(127, q));
+    return static_cast<int8_t>(q);
+}
+
+__global__ void global_amax_kernel(const __nv_bfloat16* x, int64_t n, float* amax) {
+    float local = 0.0f;
+    for (int64_t i = (int64_t)blockIdx.x * blockDim.x + threadIdx.x; i < n;
+         i += (int64_t)blockDim.x * gridDim.x)
+        local = fmaxf(local, fabsf(__bfloat162float(x[i])));
+    local = astrai::warp_reduce_max(local);
+    __shared__ float warps[32];
+    if ((threadIdx.x & 31) == 0) warps[threadIdx.x >> 5] = local;
+    __syncthreads();
+    if (threadIdx.x == 0) {
+        float value = 0.0f;
+        for (int i = 0; i < (blockDim.x + 31) / 32; ++i) value = fmaxf(value, warps[i]);
+        astrai::atomic_max_float(amax, value);
+    }
+}
+
+__global__ void scale_from_amax_kernel(const float* amax, float* scale) {
+    *scale = fmaxf(*amax / kQMax, 1e-12f);
+}
+
+__global__ void quantize_tensor_kernel(const __nv_bfloat16* x, int8_t* out,
+                                        int64_t n, const float* amax, float* scale) {
+    const float s = fmaxf(*amax / kQMax, 1e-12f);
+    if (blockIdx.x == 0 && threadIdx.x == 0) *scale = s;
+    for (int64_t i = (int64_t)blockIdx.x * blockDim.x + threadIdx.x; i < n;
+         i += (int64_t)blockDim.x * gridDim.x)
+        out[i] = quantize_s8(__bfloat162float(x[i]), s);
+}
+
+__global__ void weight_scales_kernel(const __nv_bfloat16* w, float* scales,
+                                     int n, int k) {
+    const int row = blockIdx.x;
+    if (row >= n) return;
+    float local = 0.0f;
+    for (int col = threadIdx.x; col < k; col += blockDim.x)
+        local = fmaxf(local, fabsf(__bfloat162float(w[row * k + col])));
+    local = astrai::warp_reduce_max(local);
+    __shared__ float warps[32];
+    if ((threadIdx.x & 31) == 0) warps[threadIdx.x >> 5] = local;
+    __syncthreads();
+    if (threadIdx.x == 0) {
+        float value = 0.0f;
+        for (int i = 0; i < (blockDim.x + 31) / 32; ++i) value = fmaxf(value, warps[i]);
+        scales[row] = fmaxf(value / kQMax, 1e-12f);
+    }
+}
+
+__global__ void quantize_weight_kernel(const __nv_bfloat16* w, int8_t* out,
+                                       const float* scales, int64_t total, int k) {
+    for (int64_t i = (int64_t)blockIdx.x * blockDim.x + threadIdx.x; i < total;
+         i += (int64_t)blockDim.x * gridDim.x)
+        out[i] = quantize_s8(__bfloat162float(w[i]), scales[i / k]);
+}
+
+__device__ __forceinline__ unsigned pack_s8x4(const int8_t* x, int row, int col,
+                                               int rows, int k) {
+    unsigned packed = 0;
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        const unsigned byte = row < rows && col + i < k
+            ? static_cast<unsigned>(static_cast<unsigned char>(x[(int64_t)row * k + col + i])) : 0u;
+        packed |= byte << (8 * i);
+    }
+    return packed;
+}
+
+// Correctness fallback: one warp owns one m16n8 tile. Keeping this separate
+// makes the fragment contract easy to diagnose if the CTA-tiled path regresses.
+__global__ void int8_gemm_raw_kernel(const int8_t* a, const int8_t* b,
+                                     const float* scale_a, const float* scale_b,
+                                     const __nv_bfloat16* bias, __nv_bfloat16* out,
+                                     int m, int n, int k) {
+    const int lane = threadIdx.x;
+    const int group = lane >> 2;
+    const int t4 = lane & 3;
+    const int row0 = blockIdx.y * 16;
+    const int col0 = blockIdx.x * 8;
+    int acc[4] = {0, 0, 0, 0};
+    for (int kk = 0; kk < k; kk += 32) {
+        const int k0 = kk + t4 * 4;
+        unsigned af[4];
+        af[0] = pack_s8x4(a, row0 + group, k0, m, k);
+        af[1] = pack_s8x4(a, row0 + group + 8, k0, m, k);
+        af[2] = pack_s8x4(a, row0 + group, k0 + 16, m, k);
+        af[3] = pack_s8x4(a, row0 + group + 8, k0 + 16, m, k);
+        unsigned bf[2];
+        bf[0] = pack_s8x4(b, col0 + group, k0, n, k);
+        bf[1] = pack_s8x4(b, col0 + group, k0 + 16, n, k);
+        astrai::mma_sync_s8(acc, af, bf, acc);
+    }
+    const int col = col0 + t4 * 2;
+    const float sx = *scale_a;
+    auto store = [&](int row, int column, int value) {
+        if (row < m && column < n) {
+            float y = static_cast<float>(value) * sx * scale_b[column];
+            if (bias) y += __bfloat162float(bias[column]);
+            out[(int64_t)row * n + column] = __float2bfloat16(y);
+        }
+    };
+    store(row0 + group, col, acc[0]);
+    store(row0 + group, col + 1, acc[1]);
+    store(row0 + group + 8, col, acc[2]);
+    store(row0 + group + 8, col + 1, acc[3]);
+}
+
+// CTA tiled W8A8 GEMM. A 64x64 activation tile is reused by four 64x32 warp
+// tiles across N; each warp's 64x32 weight tile is reused across 64 M rows.
+// The fragment mapping is identical to the raw kernel, but ldmatrix loads it
+// from two staged 64-wide K slices instead of repeatedly reading global memory.
+constexpr int kGemmBlockM = 64;
+constexpr int kGemmBlockN = 128;
+constexpr int kGemmBlockK = 64;
+constexpr int kGemmStages = 2;
+constexpr int kGemmThreads = 128;
+
+constexpr int kRegTileM = 64;
+constexpr int kRegTileN = 64;
+constexpr int kRegTileK = 128;
+
+constexpr int kWideTileM = 64;
+constexpr int kWideTileN = 128;
+constexpr int kWideThreads = 256;
+
+// Wide-N register tile. Eight warps cover a 64x128 CTA as 2 M-warps x 4
+// N-warps; each warp remains a 32x32 register tile, preserving the 96-register
+// accumulator footprint while reducing A tile reloads per output element.
+__global__ __launch_bounds__(kWideThreads, 2) void int8_gemm_wide_regtile_kernel(
+    const int8_t* __restrict__ a, const int8_t* __restrict__ b,
+    const float* __restrict__ scale_a, const float* __restrict__ scale_b,
+    const __nv_bfloat16* __restrict__ bias, __nv_bfloat16* __restrict__ out,
+    int m, int n, int k) {
+    __shared__ __align__(16) int8_t a_smem[kGemmStages][kWideTileM * kGemmBlockK];
+    __shared__ __align__(16) int8_t b_smem[kGemmStages][kWideTileN * kGemmBlockK];
+    const int tid = threadIdx.x, warp = tid >> 5, lane = tid & 31;
+    const int group = lane >> 2, t4 = lane & 3;
+    const int row_block = blockIdx.y * kWideTileM;
+    const int col_block = blockIdx.x * kWideTileN;
+    const int warp_m = warp >> 2, warp_n = warp & 3;
+    const int warp_row = warp_m * 32, warp_col = warp_n * 32;
+    const int r7 = lane & 7, rh8 = (lane >> 3) & 1, rh16 = lane >> 4;
+    int acc[4][2][4] = {};
+    const int tiles = (k + kGemmBlockK - 1) / kGemmBlockK;
+
+    auto stage_tile = [&](int stage, int k_base) {
+        const int a_chunk = tid;
+        const int a_row = a_chunk / 4, a_col = (a_chunk & 3) * 16;
+        int8_t* a_dst = a_smem[stage] + a_row * kGemmBlockK + a_col;
+        const bool a_full = row_block + a_row < m && k_base + a_col + 15 < k &&
+                            (k & 15) == 0;
+        if (a_full) {
+            astrai::cp_async_16(a_dst,
+                a + (int64_t)(row_block + a_row) * k + k_base + a_col, true);
+        } else {
+#pragma unroll
+            for (int j = 0; j < 16; ++j)
+                a_dst[j] = row_block + a_row < m && k_base + a_col + j < k
+                    ? a[(int64_t)(row_block + a_row) * k + k_base + a_col + j] : 0;
+        }
+#pragma unroll
+        for (int i = 0; i < 2; ++i) {
+            const int chunk = tid * 2 + i;
+            const int row = chunk / 4, col = (chunk & 3) * 16;
+            int8_t* dst = b_smem[stage] + row * kGemmBlockK + col;
+            const bool full = col_block + row < n && k_base + col + 15 < k &&
+                              (k & 15) == 0;
+            if (full) {
+                astrai::cp_async_16(dst,
+                    b + (int64_t)(col_block + row) * k + k_base + col, true);
+            } else {
+#pragma unroll
+                for (int j = 0; j < 16; ++j)
+                    dst[j] = col_block + row < n && k_base + col + j < k
+                        ? b[(int64_t)(col_block + row) * k + k_base + col + j] : 0;
+            }
+        }
+    };
+
+#pragma unroll
+    for (int stage = 0; stage < kGemmStages; ++stage) {
+        if (stage < tiles) {
+            stage_tile(stage, stage * kGemmBlockK);
+            astrai::cp_async_commit_group();
+        }
+    }
+    for (int tile = 0; tile < tiles; ++tile) {
+        const int stage = tile & 1;
+        if (tile + 1 < tiles) astrai::cp_async_wait_group<1>();
+        else astrai::cp_async_wait_group<0>();
+        __syncthreads();
+        unsigned b_frag[2][4][2];
+#pragma unroll
+        for (int nt = 0; nt < 4; ++nt) {
+            const int b_row = warp_col + nt * 8 + r7;
+            astrai::ldmatrix_x2_lane(b_frag[0][nt],
+                __cvta_generic_to_shared(b_smem[stage] + b_row * kGemmBlockK + rh8 * 16));
+        }
+#pragma unroll
+        for (int k_seg = 0; k_seg < 2; ++k_seg) {
+            const int bcur = k_seg & 1, bnext = bcur ^ 1;
+            if (k_seg == 0) {
+#pragma unroll
+                for (int nt = 0; nt < 4; ++nt) {
+                    const int b_row = warp_col + nt * 8 + r7;
+                    astrai::ldmatrix_x2_lane(b_frag[bnext][nt],
+                        __cvta_generic_to_shared(b_smem[stage] + b_row * kGemmBlockK +
+                                                 (2 + rh8) * 16));
+                }
+            }
+            unsigned a_frag[2][4];
+#pragma unroll
+            for (int mt = 0; mt < 2; ++mt) {
+                const int a_row = warp_row + mt * 16 + rh8 * 8 + r7;
+                astrai::ldmatrix_x4_lane(a_frag[mt],
+                    __cvta_generic_to_shared(a_smem[stage] + a_row * kGemmBlockK +
+                                             (k_seg * 2 + rh16) * 16));
+#pragma unroll
+                for (int nt = 0; nt < 4; ++nt)
+                    astrai::mma_sync_s8(acc[nt][mt], a_frag[mt], b_frag[bcur][nt],
+                                        acc[nt][mt]);
+            }
+        }
+        __syncthreads();
+        if (tile + kGemmStages < tiles) {
+            stage_tile(stage, (tile + kGemmStages) * kGemmBlockK);
+            astrai::cp_async_commit_group();
+        }
+    }
+
+    const float sx = *scale_a;
+#pragma unroll
+    for (int nt = 0; nt < 4; ++nt) {
+        const int col = col_block + warp_col + t4 * 2 + nt * 8;
+        if (col >= n) continue;
+        const float sw0 = scale_b[col];
+        const float sw1 = col + 1 < n ? scale_b[col + 1] : 0.0f;
+        const float bias0 = bias ? __bfloat162float(bias[col]) : 0.0f;
+        const float bias1 = bias && col + 1 < n ? __bfloat162float(bias[col + 1]) : 0.0f;
+#pragma unroll
+        for (int mt = 0; mt < 2; ++mt) {
+            const int row = row_block + warp_row + mt * 16 + group;
+            if (row < m) {
+                out[(int64_t)row * n + col] = __float2bfloat16(acc[nt][mt][0] * sx * sw0 + bias0);
+                if (col + 1 < n)
+                    out[(int64_t)row * n + col + 1] =
+                        __float2bfloat16(acc[nt][mt][1] * sx * sw1 + bias1);
+            }
+            if (row + 8 < m) {
+                out[(int64_t)(row + 8) * n + col] =
+                    __float2bfloat16(acc[nt][mt][2] * sx * sw0 + bias0);
+                if (col + 1 < n)
+                    out[(int64_t)(row + 8) * n + col + 1] =
+                        __float2bfloat16(acc[nt][mt][3] * sx * sw1 + bias1);
+            }
+        }
+    }
+}
+
+// Register-tiled candidate for medium/large M. Each warp computes a 32x32
+// output tile (2 M fragments x 4 N fragments), so each thread keeps 32 INT32
+// accumulators instead of the 64 in the 64x128 kernel. This lowers register
+// pressure and permits substantially higher resident-warp count on SM86.
+__global__ __launch_bounds__(kGemmThreads, 2) void int8_gemm_regtile_kernel(
+    const int8_t* __restrict__ a, const int8_t* __restrict__ b,
+    const float* __restrict__ scale_a, const float* __restrict__ scale_b,
+    const __nv_bfloat16* __restrict__ bias, __nv_bfloat16* __restrict__ out,
+    int m, int n, int k) {
+    __shared__ __align__(16) int8_t a_smem[kGemmStages][kRegTileM * kRegTileK];
+    __shared__ __align__(16) int8_t b_smem[kGemmStages][kRegTileN * kRegTileK];
+    const int tid = threadIdx.x, warp = tid >> 5, lane = tid & 31;
+    const int group = lane >> 2, t4 = lane & 3;
+    const int row_block = blockIdx.y * kRegTileM;
+    const int col_block = blockIdx.x * kRegTileN;
+    const int warp_m = warp >> 1, warp_n = warp & 1;
+    const int warp_row = warp_m * 32;
+    const int warp_col = warp_n * 32;
+    const int r7 = lane & 7, rh8 = (lane >> 3) & 1, rh16 = lane >> 4;
+    int acc[4][2][4] = {};  // [N fragment][M fragment][INT32 result]
+    const int tiles = (k + kRegTileK - 1) / kRegTileK;
+
+    auto stage_tile = [&](int stage, int k_base) {
+#pragma unroll
+        for (int i = 0; i < 4; ++i) {
+            const int chunk = tid * 4 + i;
+            const int row = chunk / 8, col = (chunk & 7) * 16;
+            int8_t* dst = a_smem[stage] + row * kRegTileK + col;
+            const bool full = row_block + row < m && k_base + col + 15 < k &&
+                              (k & 15) == 0;
+            if (full) {
+                astrai::cp_async_16(dst,
+                    a + (int64_t)(row_block + row) * k + k_base + col, true);
+            } else {
+#pragma unroll
+                for (int j = 0; j < 16; ++j)
+                    dst[j] = row_block + row < m && k_base + col + j < k
+                        ? a[(int64_t)(row_block + row) * k + k_base + col + j] : 0;
+            }
+        }
+#pragma unroll
+        for (int i = 0; i < 4; ++i) {
+            const int chunk = tid * 4 + i;
+            const int row = chunk / 8, col = (chunk & 7) * 16;
+            int8_t* dst = b_smem[stage] + row * kRegTileK + col;
+            const bool full = col_block + row < n && k_base + col + 15 < k &&
+                              (k & 15) == 0;
+            if (full) {
+                astrai::cp_async_16(dst,
+                    b + (int64_t)(col_block + row) * k + k_base + col, true);
+            } else {
+#pragma unroll
+                for (int j = 0; j < 16; ++j)
+                    dst[j] = col_block + row < n && k_base + col + j < k
+                        ? b[(int64_t)(col_block + row) * k + k_base + col + j] : 0;
+            }
+        }
+    };
+
+#pragma unroll
+    for (int stage = 0; stage < kGemmStages; ++stage) {
+        if (stage < tiles) {
+            stage_tile(stage, stage * kRegTileK);
+            astrai::cp_async_commit_group();
+        }
+    }
+    for (int tile = 0; tile < tiles; ++tile) {
+        const int stage = tile & 1;
+        if (tile + 1 < tiles) astrai::cp_async_wait_group<1>();
+        else astrai::cp_async_wait_group<0>();
+        __syncthreads();
+        unsigned b_frag[2][4][2];
+#pragma unroll
+        for (int nt = 0; nt < 4; ++nt) {
+            const int b_row = warp_col + nt * 8 + r7;
+            astrai::ldmatrix_x2_lane(b_frag[0][nt],
+                __cvta_generic_to_shared(b_smem[stage] + b_row * kRegTileK + rh8 * 16));
+        }
+#pragma unroll
+        for (int k_seg = 0; k_seg < 4; ++k_seg) {
+            const int bcur = k_seg & 1, bnext = bcur ^ 1;
+            if (k_seg + 1 < 4) {
+#pragma unroll
+                for (int nt = 0; nt < 4; ++nt) {
+                    const int b_row = warp_col + nt * 8 + r7;
+                    astrai::ldmatrix_x2_lane(b_frag[bnext][nt],
+                        __cvta_generic_to_shared(b_smem[stage] + b_row * kRegTileK +
+                                                 ((k_seg + 1) * 2 + rh8) * 16));
+                }
+            }
+            unsigned a_frag[2][4];
+#pragma unroll
+            for (int mt = 0; mt < 2; ++mt) {
+                const int a_row = warp_row + mt * 16 + rh8 * 8 + r7;
+                astrai::ldmatrix_x4_lane(a_frag[mt],
+                    __cvta_generic_to_shared(a_smem[stage] + a_row * kRegTileK +
+                                             (k_seg * 2 + rh16) * 16));
+#pragma unroll
+                for (int nt = 0; nt < 4; ++nt)
+                    astrai::mma_sync_s8(acc[nt][mt], a_frag[mt], b_frag[bcur][nt],
+                                        acc[nt][mt]);
+            }
+        }
+        __syncthreads();
+        if (tile + kGemmStages < tiles) {
+            stage_tile(stage, (tile + kGemmStages) * kRegTileK);
+            astrai::cp_async_commit_group();
+        }
+    }
+
+    const float sx = *scale_a;
+#pragma unroll
+    for (int nt = 0; nt < 4; ++nt) {
+        const int col = col_block + warp_col + t4 * 2 + nt * 8;
+        if (col >= n) continue;
+        const float sw0 = scale_b[col];
+        const float sw1 = col + 1 < n ? scale_b[col + 1] : 0.0f;
+        const float bias0 = bias ? __bfloat162float(bias[col]) : 0.0f;
+        const float bias1 = bias && col + 1 < n ? __bfloat162float(bias[col + 1]) : 0.0f;
+#pragma unroll
+        for (int mt = 0; mt < 2; ++mt) {
+            const int row = row_block + warp_row + mt * 16 + group;
+            if (row < m) {
+                out[(int64_t)row * n + col] = __float2bfloat16(acc[nt][mt][0] * sx * sw0 + bias0);
+                if (col + 1 < n)
+                    out[(int64_t)row * n + col + 1] =
+                        __float2bfloat16(acc[nt][mt][1] * sx * sw1 + bias1);
+            }
+            if (row + 8 < m) {
+                out[(int64_t)(row + 8) * n + col] =
+                    __float2bfloat16(acc[nt][mt][2] * sx * sw0 + bias0);
+                if (col + 1 < n)
+                    out[(int64_t)(row + 8) * n + col + 1] =
+                        __float2bfloat16(acc[nt][mt][3] * sx * sw1 + bias1);
+            }
+        }
+    }
+}
+
+__global__ __launch_bounds__(kGemmThreads, 2) void int8_gemm_tiled_kernel(
+    const int8_t* __restrict__ a, const int8_t* __restrict__ b,
+    const float* __restrict__ scale_a, const float* __restrict__ scale_b,
+    const __nv_bfloat16* __restrict__ bias, __nv_bfloat16* __restrict__ out,
+    int m, int n, int k) {
+    __shared__ __align__(16) int8_t a_smem[kGemmStages][kGemmBlockM * kGemmBlockK];
+    __shared__ __align__(16) int8_t b_smem[kGemmStages][kGemmBlockN * kGemmBlockK];
+
+    const int tid = threadIdx.x;
+    const int warp = tid >> 5;
+    const int lane = tid & 31;
+    const int group = lane >> 2;
+    const int t4 = lane & 3;
+    const int row_block = blockIdx.y * kGemmBlockM;
+    const int col_block = blockIdx.x * kGemmBlockN;
+    const int warp_col = warp * 32;
+    const int r7 = lane & 7;
+    const int rh8 = (lane >> 3) & 1;
+    const int rh16 = lane >> 4;
+
+    int acc[4][4][4] = {};  // [N warp MMA][M MMA][fragment result]
+    const int tiles = (k + kGemmBlockK - 1) / kGemmBlockK;
+
+    auto stage_tile = [&](int stage, int k_base) {
+        // Every thread moves two 16-byte A chunks and four B chunks. K is
+        // contiguous for both source operands, so cp.async is directly usable.
+#pragma unroll
+        for (int i = 0; i < 2; ++i) {
+            const int chunk = tid * 2 + i;
+            const int row = chunk / 4;
+            const int col = (chunk % 4) * 16;
+            int8_t* dst = a_smem[stage] + row * kGemmBlockK + col;
+            const bool full = row_block + row < m && k_base + col + 15 < k &&
+                              (k & 15) == 0;
+            if (full) {
+                astrai::cp_async_16(dst,
+                    a + (int64_t)(row_block + row) * k + k_base + col, true);
+            } else {
+#pragma unroll
+                for (int j = 0; j < 16; ++j)
+                    dst[j] = row_block + row < m && k_base + col + j < k
+                        ? a[(int64_t)(row_block + row) * k + k_base + col + j] : 0;
+            }
+        }
+#pragma unroll
+        for (int i = 0; i < 4; ++i) {
+            const int chunk = tid * 4 + i;
+            const int row = chunk / 4;
+            const int col = (chunk % 4) * 16;
+            int8_t* dst = b_smem[stage] + row * kGemmBlockK + col;
+            const bool full = col_block + row < n && k_base + col + 15 < k &&
+                              (k & 15) == 0;
+            if (full) {
+                astrai::cp_async_16(dst,
+                    b + (int64_t)(col_block + row) * k + k_base + col, true);
+            } else {
+#pragma unroll
+                for (int j = 0; j < 16; ++j)
+                    dst[j] = col_block + row < n && k_base + col + j < k
+                        ? b[(int64_t)(col_block + row) * k + k_base + col + j] : 0;
+            }
+        }
+    };
+
+#pragma unroll
+    for (int stage = 0; stage < kGemmStages; ++stage) {
+        if (stage < tiles) {
+            stage_tile(stage, stage * kGemmBlockK);
+            astrai::cp_async_commit_group();
+        }
+    }
+
+    for (int tile = 0; tile < tiles; ++tile) {
+        const int stage = tile % kGemmStages;
+        if (tile + 1 < tiles)
+            astrai::cp_async_wait_group<1>();
+        else
+            astrai::cp_async_wait_group<0>();
+        __syncthreads();
+
+        unsigned b_frag[2][4][2];
+#pragma unroll
+        for (int nt = 0; nt < 4; ++nt) {
+            const int b_row = warp_col + nt * 8 + r7;
+            astrai::ldmatrix_x2_lane(b_frag[0][nt],
+                __cvta_generic_to_shared(b_smem[stage] + b_row * kGemmBlockK + rh8 * 16));
+        }
+#pragma unroll
+        for (int k_seg = 0; k_seg < 2; ++k_seg) {
+            const int bcur = k_seg & 1;
+            const int bnext = bcur ^ 1;
+            if (k_seg + 1 < 2) {
+#pragma unroll
+                for (int nt = 0; nt < 4; ++nt) {
+                    const int b_row = warp_col + nt * 8 + r7;
+                    astrai::ldmatrix_x2_lane(b_frag[bnext][nt],
+                        __cvta_generic_to_shared(b_smem[stage] + b_row * kGemmBlockK +
+                                                 (2 + rh8) * 16));
+                }
+            }
+            unsigned a_frag[4][4];
+#pragma unroll
+            for (int mt = 0; mt < 4; ++mt) {
+                const int a_row = mt * 16 + rh8 * 8 + r7;
+                astrai::ldmatrix_x4_lane(a_frag[mt],
+                    __cvta_generic_to_shared(a_smem[stage] + a_row * kGemmBlockK +
+                                             (k_seg * 2 + rh16) * 16));
+#pragma unroll
+                for (int nt = 0; nt < 4; ++nt)
+                    astrai::mma_sync_s8(acc[nt][mt], a_frag[mt], b_frag[bcur][nt],
+                                        acc[nt][mt]);
+            }
+        }
+        __syncthreads();
+        if (tile + kGemmStages < tiles) {
+            stage_tile(stage, (tile + kGemmStages) * kGemmBlockK);
+            astrai::cp_async_commit_group();
+        }
+    }
+
+    const float sx = *scale_a;
+#pragma unroll
+    for (int nt = 0; nt < 4; ++nt) {
+        const int col = col_block + warp_col + t4 * 2 + nt * 8;
+        if (col >= n) continue;
+        const float sw0 = scale_b[col];
+        const float sw1 = col + 1 < n ? scale_b[col + 1] : 0.0f;
+        const float bias0 = bias ? __bfloat162float(bias[col]) : 0.0f;
+        const float bias1 = bias && col + 1 < n ? __bfloat162float(bias[col + 1]) : 0.0f;
+#pragma unroll
+        for (int mt = 0; mt < 4; ++mt) {
+            const int row = row_block + mt * 16 + group;
+            if (row < m) {
+                out[(int64_t)row * n + col] = __float2bfloat16(acc[nt][mt][0] * sx * sw0 + bias0);
+                if (col + 1 < n)
+                    out[(int64_t)row * n + col + 1] =
+                        __float2bfloat16(acc[nt][mt][1] * sx * sw1 + bias1);
+            }
+            if (row + 8 < m) {
+                out[(int64_t)(row + 8) * n + col] =
+                    __float2bfloat16(acc[nt][mt][2] * sx * sw0 + bias0);
+                if (col + 1 < n)
+                    out[(int64_t)(row + 8) * n + col + 1] =
+                        __float2bfloat16(acc[nt][mt][3] * sx * sw1 + bias1);
+            }
+        }
+    }
+}
+
+// Small-M specialization. Decode and short prefill do not have enough rows
+// to justify a 64-row CTA: this variant keeps the same four N-warps but lets
+// each warp own one m16n32 tile, avoiding 3/4 of the MMA work at M <= 16.
+__global__ __launch_bounds__(kGemmThreads, 2) void int8_gemm_small_m_kernel(
+    const int8_t* __restrict__ a, const int8_t* __restrict__ b,
+    const float* __restrict__ scale_a, const float* __restrict__ scale_b,
+    const __nv_bfloat16* __restrict__ bias, __nv_bfloat16* __restrict__ out,
+    int m, int n, int k) {
+    constexpr int kSmallTileK = 128;
+    __shared__ __align__(16) int8_t a_smem[kGemmStages][16 * kSmallTileK];
+    __shared__ __align__(16) int8_t b_smem[kGemmStages][kGemmBlockN * kSmallTileK];
+    const int tid = threadIdx.x, warp = tid >> 5, lane = tid & 31;
+    const int group = lane >> 2, t4 = lane & 3;
+    const int row_block = blockIdx.y * 16;
+    const int col_block = blockIdx.x * kGemmBlockN;
+    const int r7 = lane & 7, rh8 = (lane >> 3) & 1, rh16 = lane >> 4;
+    int acc[4][4] = {};  // [N MMA][fragment result]
+    const int tiles = (k + kSmallTileK - 1) / kSmallTileK;
+
+    auto stage_tile = [&](int stage, int k_base) {
+        // 64 A chunks and 512 B chunks. The B loop remains four chunks per
+        // thread; only the first 64 threads participate in the compact A tile.
+        for (int chunk = tid; chunk < 128; chunk += kGemmThreads) {
+            const int row = chunk / 8, col = (chunk % 8) * 16;
+            int8_t* dst = a_smem[stage] + row * kSmallTileK + col;
+            const bool full = row_block + row < m && k_base + col + 15 < k &&
+                              (k & 15) == 0;
+            if (full) {
+                astrai::cp_async_16(dst,
+                    a + (int64_t)(row_block + row) * k + k_base + col, true);
+            } else {
+#pragma unroll
+                for (int j = 0; j < 16; ++j)
+                    dst[j] = row_block + row < m && k_base + col + j < k
+                        ? a[(int64_t)(row_block + row) * k + k_base + col + j] : 0;
+            }
+        }
+#pragma unroll
+        for (int i = 0; i < 8; ++i) {
+            const int chunk = tid * 8 + i;
+            const int row = chunk / 8, col = (chunk % 8) * 16;
+            int8_t* dst = b_smem[stage] + row * kSmallTileK + col;
+            const bool full = col_block + row < n && k_base + col + 15 < k &&
+                              (k & 15) == 0;
+            if (full) {
+                astrai::cp_async_16(dst,
+                    b + (int64_t)(col_block + row) * k + k_base + col, true);
+            } else {
+#pragma unroll
+                for (int j = 0; j < 16; ++j)
+                    dst[j] = col_block + row < n && k_base + col + j < k
+                        ? b[(int64_t)(col_block + row) * k + k_base + col + j] : 0;
+            }
+        }
+    };
+
+#pragma unroll
+    for (int stage = 0; stage < kGemmStages; ++stage) {
+        if (stage < tiles) {
+            stage_tile(stage, stage * kSmallTileK);
+            astrai::cp_async_commit_group();
+        }
+    }
+    for (int tile = 0; tile < tiles; ++tile) {
+        const int stage = tile % kGemmStages;
+        if (tile + 1 < tiles) astrai::cp_async_wait_group<1>();
+        else astrai::cp_async_wait_group<0>();
+        __syncthreads();
+        unsigned b_frag[2][4][2];
+#pragma unroll
+        for (int nt = 0; nt < 4; ++nt) {
+            const int b_row = warp * 32 + nt * 8 + r7;
+            astrai::ldmatrix_x2_lane(b_frag[0][nt],
+                __cvta_generic_to_shared(b_smem[stage] + b_row * kSmallTileK + rh8 * 16));
+        }
+#pragma unroll
+        for (int k_seg = 0; k_seg < 4; ++k_seg) {
+            const int bcur = k_seg & 1, bnext = bcur ^ 1;
+            if (k_seg + 1 < 4) {
+#pragma unroll
+                for (int nt = 0; nt < 4; ++nt) {
+                    const int b_row = warp * 32 + nt * 8 + r7;
+                    astrai::ldmatrix_x2_lane(b_frag[bnext][nt],
+                        __cvta_generic_to_shared(b_smem[stage] + b_row * kSmallTileK +
+                                                 ((k_seg + 1) * 2 + rh8) * 16));
+                }
+            }
+            unsigned a_frag[4];
+            astrai::ldmatrix_x4_lane(a_frag,
+                __cvta_generic_to_shared(a_smem[stage] + (rh8 * 8 + r7) * kSmallTileK +
+                                         (k_seg * 2 + rh16) * 16));
+#pragma unroll
+            for (int nt = 0; nt < 4; ++nt)
+                astrai::mma_sync_s8(acc[nt], a_frag, b_frag[bcur][nt], acc[nt]);
+        }
+        __syncthreads();
+        if (tile + kGemmStages < tiles) {
+            stage_tile(stage, (tile + kGemmStages) * kSmallTileK);
+            astrai::cp_async_commit_group();
+        }
+    }
+    const float sx = *scale_a;
+#pragma unroll
+    for (int nt = 0; nt < 4; ++nt) {
+        const int col = col_block + warp * 32 + t4 * 2 + nt * 8;
+        const int row = row_block + group;
+        if (row >= m || col >= n) continue;
+        const float sw0 = scale_b[col];
+        const float b0 = bias ? __bfloat162float(bias[col]) : 0.0f;
+        out[(int64_t)row * n + col] = __float2bfloat16(acc[nt][0] * sx * sw0 + b0);
+        if (col + 1 < n) {
+            const float sw1 = scale_b[col + 1];
+            const float b1 = bias ? __bfloat162float(bias[col + 1]) : 0.0f;
+            out[(int64_t)row * n + col + 1] =
+                __float2bfloat16(acc[nt][1] * sx * sw1 + b1);
+        }
+        if (row + 8 < m) {
+            out[(int64_t)(row + 8) * n + col] =
+                __float2bfloat16(acc[nt][2] * sx * sw0 + b0);
+            if (col + 1 < n) {
+                const float sw1 = scale_b[col + 1];
+                const float b1 = bias ? __bfloat162float(bias[col + 1]) : 0.0f;
+                out[(int64_t)(row + 8) * n + col + 1] =
+                    __float2bfloat16(acc[nt][3] * sx * sw1 + b1);
+            }
+        }
+    }
+}
+
+// Decode has M=1, where m16 tensor-core tiles execute fifteen padded rows.
+// This GEMV path trades that waste for signed dp4a: one warp owns one output
+// channel and reduces its partial K dot product. A is staged once per 4-warp
+// CTA, so its vector is not fetched independently by every output warp.
+__global__ void int8_gemv_m1_kernel(const int8_t* __restrict__ a,
+                                    const int8_t* __restrict__ b,
+                                    const float* __restrict__ scale_a,
+                                    const float* __restrict__ scale_b,
+                                    const __nv_bfloat16* __restrict__ bias,
+                                    __nv_bfloat16* __restrict__ out, int n, int k) {
+    extern __shared__ int8_t a_smem[];
+    const int tid = threadIdx.x;
+    for (int i = tid; i < k; i += blockDim.x) a_smem[i] = a[i];
+    __syncthreads();
+
+    const int col = blockIdx.x * (blockDim.x / 32) + (tid >> 5);
+    if (col >= n) return;
+    const int lane = tid & 31;
+    int sum = 0;
+    int kk = lane * 4;
+    // Model K dimensions are multiples of four. The scalar tail preserves the
+    // public API's arbitrary-K correctness contract.
+    if ((k & 3) == 0) {
+        for (; kk + 3 < k; kk += 32 * 4) {
+            const int av = *reinterpret_cast<const int*>(a_smem + kk);
+            const int bv = *reinterpret_cast<const int*>(b + (int64_t)col * k + kk);
+            sum = __dp4a(av, bv, sum);
+        }
+    } else {
+        kk = lane;
+    }
+    for (; kk < k; kk += 32) sum += static_cast<int>(a_smem[kk]) *
+                                  static_cast<int>(b[(int64_t)col * k + kk]);
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        sum += __shfl_down_sync(0xffffffff, sum, offset);
+    if (lane == 0) {
+        float value = static_cast<float>(sum) * *scale_a * scale_b[col];
+        if (bias) value += __bfloat162float(bias[col]);
+        out[col] = __float2bfloat16(value);
+    }
+}
+
+void check_int8_device(const torch::Tensor& tensor) {
+    const auto* p = at::cuda::getDeviceProperties(tensor.device().index());
+    TORCH_CHECK(astrai::sm_at_least(p->major, p->minor,
+                                    astrai::kMinSmForInt8Major,
+                                    astrai::kMinSmForInt8Minor),
+                "INT8 MMA requires compute capability 7.5 or newer");
+}
+
+void check_bf16_cuda(const torch::Tensor& x, const char* name) {
+    TORCH_CHECK(x.is_cuda() && x.scalar_type() == torch::kBFloat16,
+                name, " must be a CUDA bfloat16 tensor");
+}
+
+std::tuple<torch::Tensor, torch::Tensor> quantize_dynamic_bf16(torch::Tensor x) {
+    check_bf16_cuda(x, "x");
+    check_int8_device(x);
+    const at::cuda::OptionalCUDAGuard guard(x.device());
+    auto stream = at::cuda::getCurrentCUDAStream();
+    auto xc = x.contiguous();
+    auto q = torch::empty_like(xc, xc.options().dtype(torch::kChar));
+    // Reuse the scale allocation as the amax scratch. The first kernel writes
+    // the reduction result; the quantization kernel converts it in-place to
+    // the public scale value, eliminating one temporary tensor allocation.
+    auto scale = torch::zeros({1}, xc.options().dtype(torch::kFloat));
+    const int blocks = std::max(1, static_cast<int>(std::min<int64_t>(
+        (static_cast<int64_t>(xc.numel()) + kThreads - 1) / kThreads, 4096)));
+    global_amax_kernel<<<blocks, kThreads, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(xc.data_ptr()), xc.numel(), scale.data_ptr<float>());
+    quantize_tensor_kernel<<<blocks, kThreads, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(xc.data_ptr()), q.data_ptr<int8_t>(),
+        xc.numel(), scale.data_ptr<float>(), scale.data_ptr<float>());
+    C10_CUDA_CHECK(cudaGetLastError());
+    return {q, scale};
+}
+
+std::tuple<torch::Tensor, torch::Tensor> quantize_weight_bf16(torch::Tensor w) {
+    check_bf16_cuda(w, "w");
+    TORCH_CHECK(w.dim() == 2, "w must have shape [N, K]");
+    check_int8_device(w);
+    const at::cuda::OptionalCUDAGuard guard(w.device());
+    auto stream = at::cuda::getCurrentCUDAStream();
+    auto wc = w.contiguous();
+    const int n = wc.size(0), k = wc.size(1);
+    auto q = torch::empty_like(wc, wc.options().dtype(torch::kChar));
+    auto scales = torch::empty({n}, wc.options().dtype(torch::kFloat));
+    weight_scales_kernel<<<n, kThreads, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(wc.data_ptr()), scales.data_ptr<float>(), n, k);
+    const int blocks = std::max(1, static_cast<int>(std::min<int64_t>(
+        (static_cast<int64_t>(wc.numel()) + kThreads - 1) / kThreads, 4096)));
+    quantize_weight_kernel<<<blocks, kThreads, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(wc.data_ptr()), q.data_ptr<int8_t>(),
+        scales.data_ptr<float>(), wc.numel(), k);
+    C10_CUDA_CHECK(cudaGetLastError());
+    return {q, scales};
+}
+
+torch::Tensor mm_int8(torch::Tensor a, torch::Tensor b, torch::Tensor scale_a,
+                      torch::Tensor scale_b, c10::optional<torch::Tensor> bias) {
+    TORCH_CHECK(a.is_cuda() && b.is_cuda() && a.scalar_type() == torch::kChar &&
+                    b.scalar_type() == torch::kChar, "a and b must be CUDA int8 tensors");
+    TORCH_CHECK(a.dim() == 2 && b.dim() == 2 && a.size(1) == b.size(1),
+                "a must be [M,K] and b must be [N,K]");
+    TORCH_CHECK(a.device() == b.device() && scale_a.device() == a.device() &&
+                    scale_b.device() == a.device(), "all tensors must share a device");
+    TORCH_CHECK(scale_a.scalar_type() == torch::kFloat && scale_a.numel() == 1 &&
+                    scale_b.scalar_type() == torch::kFloat && scale_b.numel() == b.size(0),
+                "scale_a must be float32 [1] and scale_b float32 [N]");
+    check_int8_device(a);
+    const at::cuda::OptionalCUDAGuard guard(a.device());
+    auto stream = at::cuda::getCurrentCUDAStream();
+    auto ac = a.contiguous(), bc = b.contiguous(), sb = scale_b.contiguous();
+    torch::Tensor bias_c;
+    const __nv_bfloat16* bias_ptr = nullptr;
+    if (bias.has_value() && bias->defined() && bias->numel()) {
+        TORCH_CHECK(bias->is_cuda() && bias->scalar_type() == torch::kBFloat16 &&
+                        bias->device() == a.device() && bias->numel() == b.size(0),
+                    "bias must be CUDA bfloat16 [N]");
+        bias_c = bias->contiguous();
+        bias_ptr = reinterpret_cast<const __nv_bfloat16*>(bias_c.data_ptr());
+    }
+    auto out = torch::empty({a.size(0), b.size(0)}, a.options().dtype(torch::kBFloat16));
+    if (a.size(0) == 1) {
+        constexpr int kGemvWarps = 4;
+        const int threads = kGemvWarps * 32;
+        const int blocks = (b.size(0) + kGemvWarps - 1) / kGemvWarps;
+        int8_gemv_m1_kernel<<<blocks, threads, a.size(1) * sizeof(int8_t), stream>>>(
+            ac.data_ptr<int8_t>(), bc.data_ptr<int8_t>(), scale_a.data_ptr<float>(),
+            sb.data_ptr<float>(), bias_ptr, reinterpret_cast<__nv_bfloat16*>(out.data_ptr()),
+            b.size(0), a.size(1));
+    } else if (a.size(0) <= 16) {
+        dim3 grid((b.size(0) + kGemmBlockN - 1) / kGemmBlockN,
+                  (a.size(0) + 15) / 16);
+        int8_gemm_small_m_kernel<<<grid, kGemmThreads, 0, stream>>>(
+            ac.data_ptr<int8_t>(), bc.data_ptr<int8_t>(), scale_a.data_ptr<float>(),
+            sb.data_ptr<float>(), bias_ptr, reinterpret_cast<__nv_bfloat16*>(out.data_ptr()),
+            a.size(0), b.size(0), a.size(1));
+    } else {
+        dim3 grid((b.size(0) + kRegTileN - 1) / kRegTileN,
+                  (a.size(0) + kRegTileM - 1) / kRegTileM);
+        int8_gemm_regtile_kernel<<<grid, kGemmThreads, 0, stream>>>(
+            ac.data_ptr<int8_t>(), bc.data_ptr<int8_t>(), scale_a.data_ptr<float>(),
+            sb.data_ptr<float>(), bias_ptr, reinterpret_cast<__nv_bfloat16*>(out.data_ptr()),
+            a.size(0), b.size(0), a.size(1));
+    }
+    C10_CUDA_CHECK(cudaGetLastError());
+    return out;
+}
+
+torch::Tensor linear_forward_int8(torch::Tensor x, torch::Tensor w_q,
+                                  torch::Tensor scale_w,
+                                  c10::optional<torch::Tensor> bias) {
+    check_bf16_cuda(x, "x");
+    TORCH_CHECK(w_q.dim() == 2 && w_q.scalar_type() == torch::kChar,
+                "w_q must be CUDA int8 [N,K]");
+    TORCH_CHECK(x.size(-1) == w_q.size(1), "inner dimension mismatch");
+    auto xc = x.reshape({-1, w_q.size(1)}).contiguous();
+    auto [xq, sx] = quantize_dynamic_bf16(xc);
+    auto out = mm_int8(xq, w_q, sx, scale_w, bias);
+    std::vector<int64_t> shape(x.sizes().begin(), x.sizes().end() - 1);
+    shape.push_back(w_q.size(0));
+    return out.reshape(shape);
+}
+}  // namespace
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("quantize_dynamic_bf16", &quantize_dynamic_bf16, py::arg("x"));
+    m.def("quantize_weight_bf16", &quantize_weight_bf16, py::arg("w"));
+    m.def("mm_int8", &mm_int8, py::arg("a"), py::arg("b"), py::arg("scale_a"),
+          py::arg("scale_b"), py::arg("bias") = py::none());
+    m.def("linear_forward_int8", &linear_forward_int8, py::arg("x"), py::arg("w_q"),
+          py::arg("scale_w"), py::arg("bias") = py::none());
+}

--- a/csrc/tests/int8_test.cu
+++ b/csrc/tests/int8_test.cu
@@ -1,0 +1,69 @@
+// Standalone raw INT8 MMA smoke test (no PyTorch dependency).
+// Build: nvcc -I csrc -arch=sm_86 -std=c++17 -O3 csrc/tests/int8_test.cu -o /tmp/int8_test && /tmp/int8_test
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#include "../kernels/common/mma.cuh"
+
+namespace {
+constexpr int M = 16, N = 8, K = 32;
+
+__device__ __forceinline__ unsigned pack4(const int8_t* x, int offset) {
+    unsigned out = 0;
+#pragma unroll
+    for (int i = 0; i < 4; ++i)
+        out |= static_cast<unsigned>(static_cast<unsigned char>(x[offset + i])) << (8 * i);
+    return out;
+}
+
+__global__ void mma_s8_kernel(const int8_t* a, const int8_t* b, int* out) {
+    const int lane = threadIdx.x;
+    const int group = lane >> 2, t4 = lane & 3;
+    const int k0 = t4 * 4;
+    unsigned af[4] = {
+        pack4(a, group * K + k0), pack4(a, (group + 8) * K + k0),
+        pack4(a, group * K + k0 + 16), pack4(a, (group + 8) * K + k0 + 16),
+    };
+    unsigned bf[2] = {pack4(b, group * K + k0), pack4(b, group * K + k0 + 16)};
+    int acc[4] = {0, 0, 0, 0};
+    astrai::mma_sync_s8(acc, af, bf, acc);
+    const int col = t4 * 2;
+    out[group * N + col] = acc[0];
+    out[group * N + col + 1] = acc[1];
+    out[(group + 8) * N + col] = acc[2];
+    out[(group + 8) * N + col + 1] = acc[3];
+}
+}  // namespace
+
+int main() {
+    std::vector<int8_t> a(M * K), b(N * K);
+    std::vector<int> ref(M * N, 0), out(M * N);
+    for (auto& x : a) x = static_cast<int8_t>(std::rand() % 15 - 7);
+    for (auto& x : b) x = static_cast<int8_t>(std::rand() % 15 - 7);
+    for (int m = 0; m < M; ++m)
+        for (int n = 0; n < N; ++n)
+            for (int k = 0; k < K; ++k)
+                ref[m * N + n] += static_cast<int>(a[m * K + k]) * b[n * K + k];
+
+    int8_t *da, *db;
+    int* dout;
+    cudaMalloc(&da, a.size()); cudaMalloc(&db, b.size()); cudaMalloc(&dout, out.size() * sizeof(int));
+    cudaMemcpy(da, a.data(), a.size(), cudaMemcpyHostToDevice);
+    cudaMemcpy(db, b.data(), b.size(), cudaMemcpyHostToDevice);
+    mma_s8_kernel<<<1, 32>>>(da, db, dout);
+    cudaMemcpy(out.data(), dout, out.size() * sizeof(int), cudaMemcpyDeviceToHost);
+    cudaFree(da); cudaFree(db); cudaFree(dout);
+    for (int i = 0; i < M * N; ++i) {
+        if (out[i] != ref[i]) {
+            std::fprintf(stderr, "mismatch at %d: got %d, expected %d\n", i, out[i], ref[i]);
+            return 1;
+        }
+    }
+    std::puts("INT8 MMA m16n8k32: PASS");
+    return 0;
+}

--- a/docs/guides/inference.md
+++ b/docs/guides/inference.md
@@ -11,6 +11,7 @@
 - [Engine & GenerateResult](#engine--generateresult)
 - [HTTP API](#http-api) — endpoints, SSE, errors, stats
 - [Engine API](#engine-api)
+- [Optional INT8 Decode](int8-decode.md)
 
 ## KV Cache
 

--- a/docs/guides/int8-decode.md
+++ b/docs/guides/int8-decode.md
@@ -1,0 +1,73 @@
+# INT8 Decode
+
+AstrAI's INT8 decode feature is an optional W8A8 inference optimization for
+CUDA BF16 models. It is intended for deployments with enough GPU memory to
+keep an INT8 cache in addition to the original BF16 model weights.
+
+## Design
+
+The model remains BF16 by default. When enabled, eligible `Linear` modules
+prepare a static per-output-channel INT8 weight and use dynamic symmetric INT8
+activation quantization only for a single-token decode (`M=1`). All other
+paths retain the BF16 implementation:
+
+```text
+prefill                  -> BF16 Linear/GEMM
+decode, batch > 1        -> BF16 Linear/GEMM
+decode, batch = 1        -> INT8 W8A8 GEMV when the module is eligible
+```
+
+This preserves the original BF16 fallback and avoids changing training or
+checkpoint semantics. INT8 weights are inference-only, non-persistent caches;
+they are not written to `state_dict` and increase GPU memory usage.
+
+Eligibility is a capability of the owning model component, not a global shape
+list inside `Linear`. The current dense MLP projections and `lm_head` opt in;
+attention projections and MoE experts remain opt-out until separately
+validated.
+
+If a deployment already has an INT8 weight and scale, call
+`Linear.set_int8_weights(weight_q, scale_w)` before inference. The cache is
+attached directly and the BF16-to-INT8 quantization step is skipped. The
+weight must be `[out_features, in_features]` INT8 and the scale must be FP32
+`[out_features]` on the model device.
+
+Enable the path with:
+
+```bash
+python scripts/tools/benchmark.py --ckpt params --int8-decode
+python scripts/tools/server.py --param_path params --int8-decode
+```
+
+The default remains BF16. The experimental `--int8-attention` option is not
+recommended: independent activation quantization for each attention projection
+adds launch overhead and has not shown an end-to-end benefit.
+
+## Benchmark levels
+
+Use the narrowest benchmark that answers the question:
+
+1. **Kernel level** — `scripts/tools/benchmark_int8.py` compares BF16
+   `F.linear`, activation quantization, INT8 GEMM, and fused INT8 Linear on
+   explicit `(M,K,N)` shapes.
+2. **Model decode** — `scripts/tools/benchmark.py --decode-only` measures
+   repeated model decode with scheduler/engine options and can enable or
+   disable CUDA Graphs.
+3. **End to end** — `scripts/tools/benchmark.py --end-to-end` includes prompt
+   prefill, sampling, scheduling, and generation. Its default is BF16; add
+   `--int8-decode` for the optional path.
+4. **Real testdata** — `scripts/tools/benchmark_testdata.py` measures JSONL
+   prompts. It defaults to BF16, accepts `--int8-decode` for one selected mode,
+   and accepts `--compare-int8` for a paired accuracy/performance comparison.
+
+Report CUDA Graph, batch size, prompt/output lengths, trial count, and whether
+the result is a profiler run. Decode metrics for batch sizes above one should
+distinguish batch-step latency from aggregate output-token throughput.
+
+## When to enable
+
+Enable INT8 decode when the workload is dominated by batch-1 generation and
+the GPU has sufficient headroom for the additional cached weights and CUDA
+Graph allocations. Keep the default BF16 path for memory-constrained devices,
+training, prefill-heavy workloads, or batch-oriented serving until those paths
+have their own validated INT8 kernels.

--- a/scripts/tools/benchmark.py
+++ b/scripts/tools/benchmark.py
@@ -1,4 +1,5 @@
 import json
+import statistics
 import time
 from pathlib import Path
 from typing import Optional, Union
@@ -285,6 +286,82 @@ class GenerationBenchmark:
             },
         )
 
+    def run_end_to_end_benchmark(
+        self,
+        batch_size: int = 4,
+        prompt_length: int = 512,
+        gen_length: int = 128,
+        num_trials: int = 5,
+    ) -> BenchmarkResult:
+        """Measure complete prompt-to-generation and steady-state throughput."""
+        if self.tokenizer is None:
+            raise ValueError("End-to-end benchmark requires a tokenizer")
+        phrase = "Benchmark the language model with a realistic generation prompt. "
+        prompt_ids = self.tokenizer.encode(
+            (phrase * (prompt_length // 10 + 2)).strip()
+        )[:prompt_length]
+        prompt = self.tokenizer.decode(prompt_ids, skip_special_tokens=False)
+        prompt_tokens = len(self.tokenizer.encode(prompt))
+        pool = self._make_pool(batch_size, prompt_tokens + gen_length)
+        engine = InferenceEngine(
+            model=self.model,
+            tokenizer=self.tokenizer,
+            max_batch_size=batch_size,
+            max_seq_len=prompt_tokens + gen_length,
+            cache=pool,
+            enable_cuda_graph=self.cuda_graph,
+            backend=self.backend,
+        )
+        prompts = [prompt] * batch_size
+        try:
+            list(engine.generate(prompts, stream=True, max_tokens=gen_length, temperature=0.0))
+            if self.device.startswith("cuda"):
+                torch.cuda.synchronize()
+            totals, ttfts, decode_totals, counts = [], [], [], []
+            for _ in range(num_trials):
+                start = time.perf_counter()
+                first = None
+                count = 0
+                for _item in engine.generate(
+                    prompts, stream=True, max_tokens=gen_length, temperature=0.0
+                ):
+                    count += 1
+                    if first is None:
+                        first = time.perf_counter()
+                if self.device.startswith("cuda"):
+                    torch.cuda.synchronize()
+                end = time.perf_counter()
+                total = end - start
+                ttft = first - start if first is not None else total
+                ttfts.append(ttft)
+                decode_totals.append(total - ttft)
+                totals.append(total)
+                counts.append(count)
+        finally:
+            engine.shutdown()
+
+        total = statistics.median(totals)
+        ttft = statistics.median(ttfts)
+        generated = statistics.median(counts)
+        decode_tokens = max(generated - batch_size, 1)
+        output_tps = decode_tokens / statistics.median(decode_totals)
+        return BenchmarkResult(
+            name="end_to_end",
+            batch_size=batch_size,
+            seq_len=prompt_tokens + gen_length,
+            tokens_per_second=(prompt_tokens * batch_size + generated) / total,
+            latency_ms=total * 1000.0,
+            metadata={
+                "benchmark_type": "end_to_end",
+                "num_trials": num_trials,
+                "prompt_tokens": prompt_tokens,
+                "generated_tokens": generated,
+                "ttft_ms": ttft * 1000.0,
+                "output_tps": output_tps,
+                "cuda_graph": engine.cuda_graph_enabled,
+            },
+        )
+
     def _run_graph_decode_benchmark(
         self,
         batch_size: int,
@@ -398,10 +475,25 @@ class GenerationBenchmark:
 def print_benchmark_result(result: BenchmarkResult) -> None:
     print("-" * 80)
     print(f"{result.name.upper()} — Batch={result.batch_size}, SeqLen={result.seq_len}")
-    print(f"  Throughput : {result.tokens_per_second:.1f} tokens/s")
-    print(f"  Latency    : {result.latency_ms:.2f} ms/step")
+    if result.name == "end_to_end":
+        print(f"  Total latency: {result.latency_ms:.2f} ms")
+        print(f"  TTFT         : {result.metadata['ttft_ms']:.2f} ms")
+        print(f"  Decode TPS  : {result.metadata['output_tps']:.1f} tokens/s")
+        print(f"  Total TPS   : {result.tokens_per_second:.1f} tokens/s")
+        print(f"  Prompt tokens: {result.metadata['prompt_tokens']}")
+        print(f"  Output tokens: {result.metadata['generated_tokens']}")
+    else:
+        print(f"  Throughput : {result.tokens_per_second:.1f} tokens/s")
+        print(f"  Latency    : {result.latency_ms:.2f} ms/step")
+    displayed = {
+        "benchmark_type",
+        "prompt_tokens",
+        "generated_tokens",
+        "ttft_ms",
+        "output_tps",
+    }
     for k, v in result.metadata.items():
-        if k != "benchmark_type":
+        if k not in displayed:
             print(f"  {k.replace('_', ' ').title()}: {v}")
     print("-" * 80)
 
@@ -431,6 +523,23 @@ def print_benchmark_result(result: BenchmarkResult) -> None:
 @click.option("--num_trials", type=int, default=5, help="Number of trials.")
 @click.option("--prefill_only", is_flag=True, help="Prefill benchmark only.")
 @click.option("--decode_only", is_flag=True, help="Decode benchmark only.")
+@click.option(
+    "--end_to_end",
+    "--end-to-end",
+    "end_to_end",
+    is_flag=True,
+    help="Complete prompt-to-generation benchmark only.",
+)
+@click.option(
+    "--int8-decode/--no-int8-decode",
+    default=False,
+    help="Use cached W8A8 only for supported batch-1 decode MLP projections.",
+)
+@click.option(
+    "--int8-attention/--no-int8-attention",
+    default=False,
+    help="Also use INT8 for decode q_proj/o_proj attention GEMVs.",
+)
 @click.option(
     "--cuda-graph/--no-cuda-graph",
     default=True,
@@ -465,6 +574,9 @@ def benchmark_command(
     num_trials: int,
     prefill_only: bool,
     decode_only: bool,
+    end_to_end: bool,
+    int8_decode: bool,
+    int8_attention: bool,
     cuda_graph: bool,
     ckpt: Optional[str],
     config_path: Optional[Path],
@@ -499,6 +611,11 @@ def benchmark_command(
 
     model.to(device=device, dtype=dtype_map[dtype])
     model.eval()
+    if int8_decode:
+        prepared = model.set_int8_decode_enabled(
+            True, include_attention=int8_attention
+        )
+        click.echo(f"INT8 decode: prepared {prepared} supported Linear projections")
 
     backends = _BACKENDS if compare else [backend]
 
@@ -517,6 +634,16 @@ def benchmark_command(
         click.secho(
             f"Benchmark: device={device} dtype={dtype} backend={name}", bold=True
         )
+
+        if end_to_end:
+            result = bench.run_end_to_end_benchmark(
+                batch_size=batch_size,
+                prompt_length=prompt_length,
+                gen_length=gen_length,
+                num_trials=num_trials,
+            )
+            print_benchmark_result(result)
+            continue
 
         if not decode_only:
             result = bench.run_prefill_benchmark(

--- a/scripts/tools/benchmark_int8.py
+++ b/scripts/tools/benchmark_int8.py
@@ -1,0 +1,64 @@
+"""Benchmark W8A8 primitives against BF16 linear on model-relevant shapes."""
+import argparse
+import statistics
+
+import torch
+import torch.nn.functional as F
+
+from astrai.extension.loader import is_available
+from astrai.extension.ops.int8 import (
+    linear_forward_int8,
+    mm_int8,
+    quantize_dynamic_bf16,
+    quantize_weight_bf16,
+)
+
+
+def timed(fn, warmup, iters):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    samples = []
+    for _ in range(iters):
+        start, end = torch.cuda.Event(True), torch.cuda.Event(True)
+        start.record(); fn(); end.record(); end.synchronize()
+        samples.append(start.elapsed_time(end) * 1000.0)
+    return statistics.median(samples)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--warmup", type=int, default=30)
+    parser.add_argument("--iters", type=int, default=100)
+    parser.add_argument(
+        "--shape", action="append", metavar="M,K,N",
+        help="benchmark only this shape; may be repeated (for example 16,1536,6912)",
+    )
+    args = parser.parse_args()
+    if not torch.cuda.is_available() or not is_available("int8_ops"):
+        raise SystemExit("a built int8_ops CUDA extension is required")
+    default_shapes = ((1, 1536, 6912), (16, 1536, 6912),
+                      (128, 1536, 6912), (1, 6912, 1536))
+    try:
+        shapes = tuple(tuple(map(int, item.split(","))) for item in args.shape) \
+            if args.shape else default_shapes
+    except ValueError as exc:
+        parser.error(f"--shape must be M,K,N: {exc}")
+    if any(len(shape) != 3 or min(shape) <= 0 for shape in shapes):
+        parser.error("--shape must contain three positive integers: M,K,N")
+
+    print("M K N | bf16_us quant_us int8_mm_us int8_linear_us")
+    for m, k, n in shapes:
+        x = torch.randn((m, k), device="cuda", dtype=torch.bfloat16)
+        w = torch.randn((n, k), device="cuda", dtype=torch.bfloat16)
+        wq, sw = quantize_weight_bf16(w)
+        xq, sx = quantize_dynamic_bf16(x)
+        bf16 = timed(lambda: F.linear(x, w), args.warmup, args.iters)
+        quant = timed(lambda: quantize_dynamic_bf16(x), args.warmup, args.iters)
+        gemm = timed(lambda: mm_int8(xq, wq, sx, sw), args.warmup, args.iters)
+        linear = timed(lambda: linear_forward_int8(x, wq, sw), args.warmup, args.iters)
+        print(f"{m:3d} {k:4d} {n:4d} | {bf16:7.2f} {quant:8.2f} {gemm:10.2f} {linear:13.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tools/benchmark_testdata.py
+++ b/scripts/tools/benchmark_testdata.py
@@ -1,0 +1,251 @@
+"""General generation benchmark over JSONL testdata.
+
+By default this measures the model's normal BF16 path. Use ``--int8-decode``
+to select the optional INT8 decode path, or ``--compare-int8`` to run paired
+BF16/INT8 requests on identical prompts and report output agreement.
+"""
+
+import argparse
+import json
+import statistics
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+
+from astrai.inference import InferenceEngine
+from astrai.model import AutoModel
+from astrai.tokenize import AutoTokenizer
+
+
+_DEFAULT_PROMPT = (
+    "Benchmark the language model with a realistic generation prompt. " * 16
+).strip()
+
+
+@dataclass
+class RequestResult:
+    text: str
+    prompt_tokens: int
+    output_tokens: int
+    ttft_ms: float
+    total_ms: float
+    target: str | None = None
+
+
+def _prompt(row: dict, tokenizer=None) -> str:
+    if "prompt" in row:
+        value = row["prompt"]
+        if isinstance(value, tuple):
+            value = "".join(value)
+        raw = str(value)
+        if tokenizer is not None and getattr(tokenizer, "_chat_template", None) is not None:
+            return tokenizer.apply_chat_template(
+                [{"role": "user", "content": raw}],
+                tokenize=False,
+                add_generation_prompt=True,
+            )
+        return raw
+    if "messages" in row:
+        if tokenizer is not None and getattr(tokenizer, "_chat_template", None) is not None:
+            return tokenizer.apply_chat_template(
+                row["messages"], tokenize=False, add_generation_prompt=True
+            )
+        return str(row["messages"])
+    context = str(row.get("context", ""))
+    question = str(row.get("input", row.get("question", "")))
+    return (
+        "Answer the question based on the given passages. Only give the answer "
+        "and do not output any other words.\n\nThe following are given passages.\n"
+        f"{context}\n\nQuestion: {question}\nAnswer:"
+    )
+
+
+def _norm(text: str) -> str:
+    return " ".join(text.strip().lower().split())
+
+
+def _load_rows(path: Path, limit: int) -> list[dict]:
+    rows = []
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            if line.strip():
+                rows.append(json.loads(line))
+                if limit and len(rows) >= limit:
+                    break
+    if not rows:
+        raise ValueError(f"no JSONL rows found in {path}")
+    return rows
+
+
+def _run_requests(engine, prompts: list[str], max_tokens: int) -> list[RequestResult]:
+    results = []
+    for prompt in prompts:
+        start = time.perf_counter()
+        first = None
+        pieces = []
+        for token in engine.generate(
+            prompt, stream=True, max_tokens=max_tokens, temperature=0.0
+        ):
+            if first is None:
+                first = time.perf_counter()
+            pieces.append(token)
+        end = time.perf_counter()
+        total = (end - start) * 1000.0
+        text = "".join(pieces)
+        # Tokenizer-independent fallback: output text is still comparable;
+        # callers replace this count with tokenizer IDs below when available.
+        results.append(
+            RequestResult(
+                text=text,
+                prompt_tokens=0,
+                output_tokens=0,
+                ttft_ms=((first or end) - start) * 1000.0,
+                total_ms=total,
+            )
+        )
+    return results
+
+
+def _summarize(label: str, results: list[RequestResult], tokenizer, prompts: list[str]) -> dict:
+    for result in results:
+        result.output_tokens = max(1, len(tokenizer.encode(result.text, add_special_tokens=False)))
+    for result, prompt in zip(results, prompts):
+        result.prompt_tokens = len(tokenizer.encode(prompt, add_special_tokens=False))
+    ttft = statistics.median(r.ttft_ms for r in results)
+    decode = statistics.median(
+        (r.total_ms - r.ttft_ms) / max(r.output_tokens - 1, 1) for r in results
+    )
+    total = sum(r.total_ms for r in results)
+    tokens = sum(r.output_tokens for r in results)
+    input_tokens = sum(r.prompt_tokens for r in results)
+    elapsed_s = total / 1000.0
+    return {
+        "label": label,
+        "requests": len(results),
+        "ttft_ms": ttft,
+        "decode_ms": decode,
+        "input_tps": input_tokens / elapsed_s,
+        "output_tps": tokens / elapsed_s,
+        "total_token_tps": (input_tokens + tokens) / elapsed_s,
+        "input_tokens": input_tokens,
+        "output_tokens": tokens,
+        "results": results,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ckpt", type=Path, default=Path("params"))
+    parser.add_argument(
+        "--input", type=Path, default=None,
+        help="Optional JSONL input. If omitted, use the short prompt from benchmark.py.",
+    )
+    parser.add_argument("--limit", type=int, default=1, help="Rows to test; 0 means all.")
+    parser.add_argument("--max-tokens", type=int, default=128)
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--trials", type=int, default=1, help="Measured repetitions per mode.")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--int8-decode", action="store_true",
+        help="Enable cached INT8 weights for supported M=1 decode projections.",
+    )
+    mode.add_argument(
+        "--compare-int8", action="store_true",
+        help="Run both BF16 and INT8 modes and compare generated outputs.",
+    )
+    args = parser.parse_args()
+    if args.limit < 0 or args.max_tokens <= 0 or args.warmup < 0 or args.trials <= 0:
+        parser.error("limit must be >= 0, max-tokens/trials > 0, warmup >= 0")
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA is required for this benchmark")
+
+    if args.input is None:
+        rows = [{"prompt": _DEFAULT_PROMPT}]
+    else:
+        rows = _load_rows(args.input, args.limit)
+    tokenizer = AutoTokenizer.from_pretrained(args.ckpt)
+    prompts = [_prompt(row, tokenizer) for row in rows]
+    targets = [row.get("target_text") for row in rows]
+    model = AutoModel.from_pretrained(args.ckpt).to("cuda", dtype=torch.bfloat16).eval()
+
+    def run_mode(enabled: bool):
+        model.set_int8_decode_enabled(enabled)
+        # Weight preparation and graph capture must belong to the selected
+        # mode; switching a live engine would replay the previously captured
+        # BF16 graph and also charge quantization to INT8 TTFT.
+        torch.cuda.synchronize()
+        max_seq_len = max(
+            len(tokenizer.encode(prompt, add_special_tokens=False)) + args.max_tokens
+            for prompt in prompts
+        )
+        engine = InferenceEngine(
+            model=model,
+            tokenizer=tokenizer,
+            max_batch_size=1,
+            max_seq_len=max_seq_len,
+        )
+        try:
+            for _ in range(args.warmup):
+                _run_requests(engine, prompts[:1], min(args.max_tokens, 8))
+            torch.cuda.synchronize()
+            measured = []
+            for _ in range(args.trials):
+                measured.extend(_run_requests(engine, prompts, args.max_tokens))
+            return _summarize(
+                "INT8" if enabled else "BF16",
+                measured,
+                tokenizer,
+                prompts * args.trials,
+            )
+        finally:
+            engine.shutdown()
+
+    summaries = [run_mode(args.int8_decode)] if not args.compare_int8 else [run_mode(False), run_mode(True)]
+    print(f"Testdata benchmark: {args.input or 'benchmark.py short prompt'}")
+    print(f"Requests={len(rows)} trials={args.trials} max_tokens={args.max_tokens}")
+    for summary in summaries:
+        print(
+            f"{summary['label']:4s} | TTFT {summary['ttft_ms']:.2f} ms | "
+            f"Decode {summary['decode_ms']:.2f} ms/token | "
+            f"Input TPS {summary['input_tps']:.2f} | "
+            f"Output TPS {summary['output_tps']:.2f} | "
+            f"Total-token TPS {summary['total_token_tps']:.2f} | "
+            f"Input tokens {summary['input_tokens']} | Output tokens {summary['output_tokens']}"
+        )
+    if args.compare_int8:
+        bf16, int8 = summaries
+        if bf16["output_tokens"] == int8["output_tokens"]:
+            print(f"INT8 speedup (decode): {bf16['decode_ms'] / int8['decode_ms']:.3f}x")
+        else:
+            print("INT8 speedup (decode): not comparable (different token counts)")
+        agreement = sum(
+            _norm(a.text) == _norm(b.text)
+            for a, b in zip(bf16["results"], int8["results"])
+        ) / max(len(bf16["results"]), 1)
+        print(
+            "Normalized output agreement: "
+            f"{agreement * 100:.2f}% "
+            "(case/whitespace-normalized final text)"
+        )
+    if args.int8_decode:
+        print("Mode: INT8 decode enabled (supported M=1 projections only)")
+    else:
+        print("Mode: BF16 baseline")
+    if args.compare_int8:
+        bf16, int8 = summaries
+    scored = [(idx, target) for idx, target in enumerate(targets) if target is not None]
+    if scored:
+        if args.compare_int8:
+            bf16_acc = sum(_norm(bf16["results"][idx].text) == _norm(str(target)) for idx, target in scored) / len(scored)
+            int8_acc = sum(_norm(int8["results"][idx].text) == _norm(str(target)) for idx, target in scored) / len(scored)
+            print(f"Target exact-match: BF16 {bf16_acc * 100:.2f}% | INT8 {int8_acc * 100:.2f}%")
+        else:
+            label = summaries[0]["label"]
+            accuracy = sum(_norm(summaries[0]["results"][idx].text) == _norm(str(target)) for idx, target in scored) / len(scored)
+            print(f"Target exact-match: {label} {accuracy * 100:.2f}%")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tools/server.py
+++ b/scripts/tools/server.py
@@ -22,6 +22,8 @@ _SERVER_KEYS = (
     "dtype",
     "max_batch_size",
     "max_seq_len",
+    "int8_decode",
+    "int8_attention",
 )
 
 
@@ -88,6 +90,20 @@ _SPECS = [
         default=None,
         help="Maximum sequence length (KV cache size + prompt truncation). "
         "Uses model config if not set.",
+    ),
+    OptSpec(
+        "int8_decode",
+        "Performance",
+        is_flag=True,
+        default=False,
+        help="Use cached INT8 weights for supported batch-1 decode projections.",
+    ),
+    OptSpec(
+        "int8_attention",
+        "Performance",
+        is_flag=True,
+        default=False,
+        help="Also use INT8 for supported decode attention projections.",
     ),
 ]
 
@@ -168,6 +184,8 @@ def server_command(ctx, config_path, **kwargs):
         param_path=Path(kwargs["param_path"]),
         max_batch_size=kwargs["max_batch_size"],
         max_seq_len=kwargs["max_seq_len"],
+        int8_decode=kwargs["int8_decode"],
+        int8_attention=kwargs["int8_attention"],
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -137,13 +137,18 @@ class _CMakeBuildExt(_build_ext):
         # CMake may report partial‑target success even if some architecture‑specific kernels are skipped.
         # Prevent editable install from reporting success when critical kernel shared objects are missing.
         lib_dir = src / "astrai" / "extension" / "lib"
-        required = (
+        required = [
             "attn_decode",
             "attn_prefill",
             "attn_paged_decode",
             "attn_paged_prefill",
             "rotary_emb",
-        )
+        ]
+        try:
+            if arch is None or int(str(arch)) >= 75:
+                required.append("int8_ops")
+        except ValueError:
+            required.append("int8_ops")
         missing = [name for name in required if not any(lib_dir.glob(f"{name}.*.so"))]
         if missing:
             raise RuntimeError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,11 @@ FP8_AVAIL = (
     and is_available("quantize")
     and torch.cuda.get_device_capability() >= (8, 9)
 )
+INT8_AVAIL = (
+    CUDA_AVAIL
+    and is_available("int8_ops")
+    and torch.cuda.get_device_capability() >= (7, 5)
+)
 skip_no_cuda = pytest.mark.skipif(not CUDA_AVAIL, reason="CUDA not available")
 skip_lt2_cuda = pytest.mark.skipif(
     not CUDA_AVAIL or torch.cuda.device_count() < 2,
@@ -29,6 +34,10 @@ skip_no_kernel = pytest.mark.skipif(not KERNEL_AVAIL, reason="CUDA kernels not b
 skip_no_fp8 = pytest.mark.skipif(
     not FP8_AVAIL,
     reason="fused FP8 MMA requires a built kernel and compute capability 8.9+",
+)
+skip_no_int8 = pytest.mark.skipif(
+    not INT8_AVAIL,
+    reason="fused INT8 MMA requires a built kernel and compute capability 7.5+",
 )
 
 

--- a/tests/extension/test_int8_mma.py
+++ b/tests/extension/test_int8_mma.py
@@ -1,0 +1,84 @@
+import pytest
+import torch
+
+from astrai.extension.ops.int8 import (
+    linear_forward_int8,
+    mm_int8,
+    quantize_dynamic_bf16,
+    quantize_weight_bf16,
+)
+from tests.conftest import skip_no_int8
+
+
+def _reference(aq, wq, sx, sw, bias=None):
+    # PyTorch does not implement CUDA int32 addmm. For CUDA inputs, FP32
+    # exactly accumulates these test values (well below its 24-bit integer
+    # mantissa limit) and therefore remains an INT32-equivalent reference.
+    if aq.is_cuda:
+        out = aq.float() @ wq.float().transpose(0, 1)
+    else:
+        out = (aq.to(torch.int32) @ wq.to(torch.int32).transpose(0, 1)).float()
+    out = out * sx.float().reshape(1, 1) * sw.float().reshape(1, -1)
+    if bias is not None:
+        out = out + bias.float().reshape(1, -1)
+    return out.to(torch.bfloat16)
+
+
+def test_int8_quantization_cpu_reference_and_zero_scale():
+    x = torch.tensor([[0.0, 1.0, -1.0, 200.0]], dtype=torch.bfloat16)
+    q, scale = quantize_dynamic_bf16(x)
+    assert q.dtype == torch.int8 and scale.shape == (1,)
+    assert scale.item() == pytest.approx(200.0 / 127.0)
+    assert torch.equal(q, torch.tensor([[0, 1, -1, 127]], dtype=torch.int8))
+
+    wq, sw = quantize_weight_bf16(torch.zeros((3, 7), dtype=torch.bfloat16))
+    assert torch.equal(wq, torch.zeros_like(wq))
+    torch.testing.assert_close(sw, torch.full((3,), 1e-12, dtype=torch.float32))
+
+
+@pytest.mark.parametrize(("m", "n", "k"), [(16, 8, 32), (17, 9, 33), (64, 128, 64)])
+def test_int8_mm_cpu_matches_explicit_int32(m, n, k):
+    torch.manual_seed(m + n + k)
+    x = torch.randn((m, k), dtype=torch.bfloat16)
+    w = torch.randn((n, k), dtype=torch.bfloat16)
+    aq, sx = quantize_dynamic_bf16(x)
+    wq, sw = quantize_weight_bf16(w)
+    out = mm_int8(aq, wq, sx, sw)
+    torch.testing.assert_close(out, _reference(aq, wq, sx, sw))
+
+
+def test_int8_linear_cpu_static_weight_bias_and_leading_dims():
+    torch.manual_seed(9)
+    x = torch.randn((2, 3, 37), dtype=torch.bfloat16)
+    w = torch.randn((13, 37), dtype=torch.bfloat16)
+    bias = torch.randn(13, dtype=torch.bfloat16)
+    wq, sw = quantize_weight_bf16(w)
+    out = linear_forward_int8(x, wq, sw, bias)
+    xq, sx = quantize_dynamic_bf16(x.reshape(-1, 37))
+    expected = _reference(xq, wq, sx, sw, bias).reshape(2, 3, 13)
+    torch.testing.assert_close(out, expected)
+
+
+@skip_no_int8
+@pytest.mark.parametrize(("m", "n", "k"), [(16, 8, 32), (17, 9, 33), (64, 128, 64)])
+def test_int8_mma_cuda_matches_explicit_int32(m, n, k):
+    torch.manual_seed(m + n + k)
+    x = torch.randn((m, k), device="cuda", dtype=torch.bfloat16)
+    w = torch.randn((n, k), device="cuda", dtype=torch.bfloat16)
+    aq, sx = quantize_dynamic_bf16(x)
+    wq, sw = quantize_weight_bf16(w)
+    out = mm_int8(aq, wq, sx, sw)
+    torch.testing.assert_close(out, _reference(aq, wq, sx, sw), atol=1e-2, rtol=1e-2)
+
+
+@skip_no_int8
+@pytest.mark.parametrize(("m", "n", "k"), [(1, 6912, 1536), (16, 6912, 1536), (128, 1536, 6912)])
+def test_int8_linear_cuda_model_shapes(m, n, k):
+    torch.manual_seed(m + n + k)
+    x = torch.randn((m, k), device="cuda", dtype=torch.bfloat16)
+    w = torch.randn((n, k), device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn(n, device="cuda", dtype=torch.bfloat16)
+    wq, sw = quantize_weight_bf16(w)
+    out = linear_forward_int8(x, wq, sw, bias)
+    xq, sx = quantize_dynamic_bf16(x)
+    torch.testing.assert_close(out, _reference(xq, wq, sx, sw, bias), atol=1e-2, rtol=1e-2)

--- a/tests/module/test_linear_int8_decode.py
+++ b/tests/module/test_linear_int8_decode.py
@@ -1,0 +1,73 @@
+import torch
+import torch.nn.functional as F
+
+from astrai.extension.ops.int8 import linear_forward_int8
+from astrai.model.components.linear import Linear
+from tests.conftest import skip_no_int8
+
+
+def test_int8_decode_switch_keeps_cpu_linear_on_bf16_fallback():
+    layer = Linear(4, 5, bias=True).to(dtype=torch.bfloat16).eval()
+    x = torch.randn(1, 4, dtype=torch.bfloat16)
+
+    assert not layer.set_int8_decode_enabled(True)
+    with torch.no_grad():
+        actual = layer(x)
+        expected = F.linear(x, layer.weight, layer.bias)
+
+    torch.testing.assert_close(actual, expected)
+    assert layer._int8_weight is None
+    assert layer._int8_scale is None
+
+
+def test_int8_decode_switch_clears_inference_cache():
+    layer = Linear(4, 5)
+    layer._int8_weight = torch.empty((5, 4), dtype=torch.int8)
+    layer._int8_scale = torch.ones(5, dtype=torch.float32)
+    layer._int8_weight_version = 7
+
+    assert not layer.set_int8_decode_enabled(False)
+    assert layer._int8_weight is None
+    assert layer._int8_scale is None
+    assert layer._int8_weight_version == -1
+    assert not layer._int8_weights_external
+
+
+def test_lm_head_role_allows_int8_for_large_vocab_shape():
+    layer = Linear(4, 100000, int8_decode_supported=True)
+    assert layer.int8_decode_eligible
+
+
+def test_prequantized_weight_is_attached_without_requantization():
+    layer = Linear(4, 5, int8_decode_supported=True)
+    weight_q = torch.ones((5, 4), dtype=torch.int8)
+    scale_w = torch.full((5,), 0.25, dtype=torch.float32)
+
+    assert layer.set_int8_weights(weight_q, scale_w)
+    assert layer._int8_decode_enabled
+    assert layer._int8_weights_external
+    assert torch.equal(layer._int8_weight, weight_q)
+    assert torch.equal(layer._int8_scale, scale_w)
+
+
+def test_attention_shape_stays_disabled_until_shared_quantization_exists():
+    layer = Linear(1536, 1536)
+    assert not layer.int8_decode_eligible
+
+
+@skip_no_int8
+def test_int8_decode_uses_cached_weight_for_supported_single_token_shape():
+    torch.manual_seed(11)
+    layer = Linear(
+        1536, 6912, int8_decode_supported=True
+    ).to(device="cuda", dtype=torch.bfloat16).eval()
+    x = torch.randn((1, 1536), device="cuda", dtype=torch.bfloat16)
+
+    assert layer.set_int8_decode_enabled(True)
+    assert layer._int8_weight is not None
+    assert layer._int8_scale is not None
+    with torch.no_grad():
+        actual = layer(x)
+        expected = linear_forward_int8(x, layer._int8_weight, layer._int8_scale)
+
+    torch.testing.assert_close(actual, expected)


### PR DESCRIPTION
## Description

This PR integrates an optional INT8 GEMV acceleration path for the decode stage.

The implementation keeps the existing BF16 weights as the primary weights and prepares cached INT8 weights for supported decode projections. INT8 decode is opt-in and does not change the default BF16 execution path.

## Current Scope

The current implementation provides pluggable INT8 GEMV acceleration for supported `M=1` decode projections.

- INT8 decode is enabled only when explicitly requested.
- 73 supported Linear projections are currently prepared.
- Unsupported shapes and unsupported calculation paths continue to use BF16.
- Batch > 1 and prefill paths do not use the INT8 GEMV path.
- The implementation avoids hard-coded shape dispatch and uses explicit operator capability declarations.
- Pre-quantized INT8 weights can be attached directly without repeating quantization.

This feature is intended as an optional decode acceleration path for deployments with sufficient GPU memory to hold both BF16 and INT8 weight representations.

## Performance

Test environment:

- Backend: CUDA
- Dtype: BF16
- CUDA Graph: enabled
- Batch size: 1
- Prompt length: 512
- Generation length: 128

### Operator benchmark

For `M=1`, INT8 provides a clear advantage over BF16:

```text
M    K     N       BF16(us)  INT8 Linear(us)
1    1536  6912    236.48    147.28
1    6912  1536    230.40    168.37
```

For larger M values, INT8 does not currently provide sufficient benefit:

```
M=16   1536x6912: BF16 236.35 us, INT8 328.70 us
M=128  1536x6912: BF16 338.43 us, INT8 355.25 us
```

Therefore, INT8 decode integration is intentionally limited to the supported `M=1` path.

### Decode benchmark

```
BF16: 42.6 tokens/s
INT8: 51.9 tokens/s
```

Decode speedup:

```
1.22x
```

### End-to-end benchmark

```
BF16:
Total latency: 2947.77 ms
TTFT:          175.32 ms
Decode TPS:    45.8 tokens/s
Total TPS:     217.1 tokens/s

INT8:
Total latency: 2120.19 ms
TTFT:          194.06 ms
Decode TPS:    65.9 tokens/s
Total TPS:     301.9 tokens/s
```

Observed speedup:

```
Decode TPS: approximately 1.44x
Total TPS : approximately 1.39x
```

The TTFT difference is affected by prefill and runtime conditions. The INT8 path is primarily intended to accelerate steady-state decode.

## Benchmark Improvements

This PR also generalizes the benchmark tooling:

- `scripts/tools/benchmark.py` is a general model benchmark tool.
- INT8 decode is disabled by default.
- `--int8-decode` enables the optional INT8 decode path.
- `--compare` remains available for backend comparison.
- `scripts/tools/benchmark_testdata.py` supports real-text JSONL benchmark data.
- `--compare-int8` runs BF16 and INT8 on identical prompts.
- The testdata benchmark reports decode throughput, total token throughput, and output agreement.
- Real-text generation tests verify that the INT8 path preserves generated outputs for the tested cases.

The current real-text comparison produced:

```
BF16 decode: 21.94 ms/token
INT8 decode: 16.19 ms/token
Decode speedup: 1.355x
Normalized output agreement: 100%
```

The output agreement compares paired final outputs after case and whitespace normalization.

## Testing

Operator benchmark:

```
python scripts/tools/benchmark_int8.py \
  --warmup 30 \
  --iters 100
```

Decode benchmark:

```
python scripts/tools/benchmark.py \
  --ckpt params \
  --backend cuda \
  --batch_size 1 \
  --prompt_length 512 \
  --gen_length 128 \
  --num_trials 5 \
  --decode_only \
  --cuda-graph \
  --int8-decode
```

End-to-end benchmark:

```
python scripts/tools/benchmark.py \
  --ckpt params \
  --backend cuda \
  --batch_size 1 \
  --prompt_length 512 \
  --gen_length 128 \
  --num_trials 5 \
  --end_to_end \
  --cuda-graph \
  --int8-decode
```

Real-text BF16/INT8 comparison:

```
python scripts/tools/benchmark_testdata.py \
  --ckpt params \
  --max-tokens 1024 \
  --warmup 2 \
  --trials 10 \
  --compare-int8
```

Unit and integration tests were also run for the INT8 extension, Linear integration, forward paths, and serving CLI.

## Future Work

1. Improve INT8 GEMM/GEMV kernels for larger M values and additional matrix shapes.
2. Expand INT8 decode coverage to more decode calculation paths once their performance is competitive with BF16.
3. Evaluate a primary-INT8 weight layout for deployments using INT8 checkpoints directly.
4. Reduce the memory overhead of maintaining both BF16 and INT8 weight representations.
5. Extend the benchmark suite with broader real-world testdata and batch-size coverage.

## Type of Change

- New feature
- Documentation update
- Tests and benchmark updates