### PR TITLE
fix(eval): import InferenceEngine so evaluate_humaneval.py can be imported

### DIFF
--- a/scripts/eval/evaluate_humaneval.py
+++ b/scripts/eval/evaluate_humaneval.py
@@ -21,7 +21,7 @@ import numpy as np
 import tqdm
 from datasets import load_dataset
 
-from astrai.inference import build_engine
+from astrai.inference import InferenceEngine, build_engine
 
 # ---------------------------------------------------------------------------
 # Config


### PR DESCRIPTION
### Problem

`scripts/eval/evaluate_humaneval.py` cannot be imported at all — it raises `NameError` before a single line of benchmark code runs.

Line 24 imports only `build_engine`:

```python
from astrai.inference import build_engine
```

but `InferenceEngine` is used as a **function-signature annotation** in two places:

```python
def generate_batch(
    engine: InferenceEngine,     # L132
    ...

def evaluate_problem(
    engine: InferenceEngine,     # L172
    ...
```

The file has no `from __future__ import annotations`, so signature annotations are evaluated when the `def` statement executes at module import time. `InferenceEngine` is never bound in the module namespace, so importing (or running) the script fails immediately:

```
NameError: name 'InferenceEngine' is not defined
```

Repro of the exact import + annotation shape, with the real package stubbed out so only the name binding is under test:

```
main (unpatched)   -> NameError: name 'InferenceEngine' is not defined
with fix           -> imported OK
```

### Fix

Add `InferenceEngine` to the existing import. `astrai/inference/__init__.py` already re-exports it:

```python
from astrai.inference.engine import InferenceEngine, build_engine
```

and the same import form is used elsewhere in the tree — `astrai/inference/network/app.py:21`:

```python
from astrai.inference.engine import InferenceEngine, build_engine
```

so the added name is ordered consistently with existing usage and `ruff check --select I` is unaffected.

One line changed, no behaviour change beyond the module now importing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
